### PR TITLE
Fix MarkupError when opening error files with special characters

### DIFF
--- a/stoei/widgets/screens.py
+++ b/stoei/widgets/screens.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from typing import ClassVar
 
+from rich.text import Text
 from textual.app import ComposeResult
 from textual.containers import Container, Vertical, VerticalScroll
 from textual.screen import Screen
@@ -68,7 +69,7 @@ class LogViewerScreen(Screen[None]):
                     yield Static(f"⚠️  {self.load_error}", id="log-error-text")
             else:
                 with VerticalScroll(id="log-content-scroll"):
-                    yield Static(self.file_contents, id="log-content-text")
+                    yield Static(self.file_contents, id="log-content-text", markup=False)
 
             with Container(id="log-viewer-footer"):
                 yield Static(
@@ -221,7 +222,10 @@ class LogViewerScreen(Screen[None]):
             if self.load_error:
                 content_widget.update(f"⚠️  {self.load_error}")
             else:
-                content_widget.update(self.file_contents)
+                # Update with plain text to prevent MarkupError
+                # Use Text to ensure content is treated as plain text
+                plain_text = Text(self.file_contents)
+                content_widget.update(plain_text)
             self.app.notify("File reloaded")
             logger.info(f"Reloaded log file: {self.filepath}")
         except Exception as exc:


### PR DESCRIPTION
## Problem
When opening error files containing special characters like `=`, the LogViewerScreen would raise a `MarkupError` because Rich's markup parser tried to interpret these characters as markup syntax.

## Solution
- Disabled markup parsing for file content in LogViewerScreen by setting `markup=False` on the Static widget
- Updated the reload method to use Rich's `Text` class for plain text content
- Added comprehensive tests to prevent regression

## Testing
- All 465 tests pass
- Added two new tests specifically for markup-like characters:
  - `test_load_file_with_markup_special_chars`: Unit test for file loading
  - `test_log_viewer_screen_renders_markup_special_chars`: Integration test for screen rendering

## Changes
- `stoei/widgets/screens.py`: Disabled markup and use Text for plain content
- `tests/test_widgets/test_screens.py`: Added regression tests

Fixes the issue where files with content like `"=3', 'model=test', ..."` would cause a MarkupError.