### PR TITLE
Add GPU type tracking and display in user overview tab

### DIFF
--- a/tests/test_widgets/test_user_overview.py
+++ b/tests/test_widgets/test_user_overview.py
@@ -16,6 +16,7 @@ class TestUserStats:
             total_memory_gb=100.0,
             total_gpus=2,
             total_nodes=3,
+            gpu_types="2x H200",
         )
         assert stats.username == "testuser"
         assert stats.job_count == 5
@@ -23,6 +24,7 @@ class TestUserStats:
         assert stats.total_memory_gb == 100.0
         assert stats.total_gpus == 2
         assert stats.total_nodes == 3
+        assert stats.gpu_types == "2x H200"
 
 
 class TestUserOverviewTab:
@@ -56,6 +58,7 @@ class TestUserOverviewTab:
                     total_memory_gb=64.0,
                     total_gpus=1,
                     total_nodes=2,
+                    gpu_types="1x GPU",
                 ),
                 UserStats(
                     username="user2",
@@ -64,6 +67,7 @@ class TestUserOverviewTab:
                     total_memory_gb=128.0,
                     total_gpus=2,
                     total_nodes=3,
+                    gpu_types="2x GPU",
                 ),
             ]
             user_tab.update_users(users)
@@ -157,6 +161,7 @@ class TestUserOverviewTab:
                     total_memory_gb=50.0,
                     total_gpus=0,
                     total_nodes=1,
+                    gpu_types="",
                 ),
                 UserStats(
                     username="user2",
@@ -165,6 +170,7 @@ class TestUserOverviewTab:
                     total_memory_gb=200.0,
                     total_gpus=2,
                     total_nodes=5,
+                    gpu_types="2x GPU",
                 ),
                 UserStats(
                     username="user3",
@@ -173,6 +179,7 @@ class TestUserOverviewTab:
                     total_memory_gb=25.0,
                     total_gpus=0,
                     total_nodes=1,
+                    gpu_types="",
                 ),
             ]
             user_tab.update_users(users)
@@ -184,49 +191,71 @@ class TestUserOverviewTab:
     def test_parse_tres_with_memory_gb(self) -> None:
         """Test parsing TRES with memory in GB."""
         tres_str = "cpu=32,mem=256G,node=4,gres/gpu=16"
-        cpus, memory_gb, gpus = UserOverviewTab._parse_tres(tres_str)
+        cpus, memory_gb, gpu_entries = UserOverviewTab._parse_tres(tres_str)
         assert cpus == 32
         assert memory_gb == 256.0
-        assert gpus == 16
+        assert len(gpu_entries) == 1
+        assert gpu_entries[0] == ("gpu", 16)
 
     def test_parse_tres_with_memory_mb(self) -> None:
         """Test parsing TRES with memory in MB (converted to GB)."""
         tres_str = "cpu=8,mem=8192M,node=1,gres/gpu=1"
-        cpus, memory_gb, gpus = UserOverviewTab._parse_tres(tres_str)
+        cpus, memory_gb, gpu_entries = UserOverviewTab._parse_tres(tres_str)
         assert cpus == 8
         assert memory_gb == 8.0  # 8192 MB / 1024 = 8 GB
-        assert gpus == 1
+        assert len(gpu_entries) == 1
+        assert gpu_entries[0] == ("gpu", 1)
 
     def test_parse_tres_without_gpus(self) -> None:
         """Test parsing TRES without GPU information."""
         tres_str = "cpu=16,mem=128G,node=2"
-        cpus, memory_gb, gpus = UserOverviewTab._parse_tres(tres_str)
+        cpus, memory_gb, gpu_entries = UserOverviewTab._parse_tres(tres_str)
         assert cpus == 16
         assert memory_gb == 128.0
-        assert gpus == 0
+        assert len(gpu_entries) == 0
 
     def test_parse_tres_without_memory(self) -> None:
         """Test parsing TRES without memory information."""
         tres_str = "cpu=32,node=4,gres/gpu=8"
-        cpus, memory_gb, gpus = UserOverviewTab._parse_tres(tres_str)
+        cpus, memory_gb, gpu_entries = UserOverviewTab._parse_tres(tres_str)
         assert cpus == 32
         assert memory_gb == 0.0
-        assert gpus == 8
+        assert len(gpu_entries) == 1
+        assert gpu_entries[0] == ("gpu", 8)
 
     def test_parse_tres_empty_string(self) -> None:
         """Test parsing empty TRES string."""
-        cpus, memory_gb, gpus = UserOverviewTab._parse_tres("")
+        cpus, memory_gb, gpu_entries = UserOverviewTab._parse_tres("")
         assert cpus == 0
         assert memory_gb == 0.0
-        assert gpus == 0
+        assert len(gpu_entries) == 0
 
     def test_parse_tres_invalid_format(self) -> None:
         """Test parsing invalid TRES format."""
         tres_str = "invalid format"
-        cpus, memory_gb, gpus = UserOverviewTab._parse_tres(tres_str)
+        cpus, memory_gb, gpu_entries = UserOverviewTab._parse_tres(tres_str)
         assert cpus == 0
         assert memory_gb == 0.0
-        assert gpus == 0
+        assert len(gpu_entries) == 0
+
+    def test_parse_tres_with_gpu_types(self) -> None:
+        """Test parsing TRES with GPU type information."""
+        tres_str = "cpu=32,mem=256G,node=4,gres/gpu:h200=8"
+        cpus, memory_gb, gpu_entries = UserOverviewTab._parse_tres(tres_str)
+        assert cpus == 32
+        assert memory_gb == 256.0
+        assert len(gpu_entries) == 1
+        assert gpu_entries[0] == ("h200", 8)
+
+    def test_parse_tres_with_multiple_gpu_types(self) -> None:
+        """Test parsing TRES with multiple GPU types."""
+        tres_str = "cpu=32,mem=256G,node=4,gres/gpu:h200=8,gres/gpu:a100=4"
+        cpus, memory_gb, gpu_entries = UserOverviewTab._parse_tres(tres_str)
+        assert cpus == 32
+        assert memory_gb == 256.0
+        assert len(gpu_entries) == 2
+        assert ("h200", 8) in gpu_entries
+        assert ("a100", 4) in gpu_entries
 
     def test_aggregate_user_stats_with_tres_memory(self) -> None:
         """Test aggregating stats with TRES memory information."""
@@ -240,6 +269,7 @@ class TestUserOverviewTab:
         assert result[0].total_memory_gb == 384.0  # 256 + 128
         assert result[0].total_gpus == 12  # 8 + 4
         assert result[0].total_cpus == 48  # 32 + 16
+        assert result[0].gpu_types == "12x GPU"
 
     def test_aggregate_user_stats_with_tres_memory_mb(self) -> None:
         """Test aggregating stats with TRES memory in MB."""
@@ -250,6 +280,7 @@ class TestUserOverviewTab:
         assert len(result) == 1
         assert result[0].total_memory_gb == 8.0  # 8192 MB / 1024 = 8 GB
         assert result[0].total_gpus == 1
+        assert result[0].gpu_types == "1x GPU"
 
     def test_aggregate_user_stats_with_tres_multiple_users(self) -> None:
         """Test aggregating stats with TRES for multiple users."""
@@ -265,9 +296,11 @@ class TestUserOverviewTab:
         assert user1.total_memory_gb == 320.0  # 256 + 64
         assert user1.total_gpus == 10  # 8 + 2
         assert user1.total_cpus == 40  # 32 + 8
+        assert user1.gpu_types == "10x GPU"
         assert user2.total_memory_gb == 128.0
         assert user2.total_gpus == 4
         assert user2.total_cpus == 16
+        assert user2.gpu_types == "4x GPU"
 
     def test_aggregate_user_stats_without_tres(self) -> None:
         """Test aggregating stats when TRES field is missing."""
@@ -280,6 +313,7 @@ class TestUserOverviewTab:
         assert result[0].total_cpus == 2  # Based on nodes
         assert result[0].total_memory_gb == 0.0
         assert result[0].total_gpus == 0
+        assert result[0].gpu_types == ""
 
     def test_aggregate_user_stats_with_empty_tres(self) -> None:
         """Test aggregating stats when TRES field is empty."""
@@ -292,6 +326,7 @@ class TestUserOverviewTab:
         assert result[0].total_cpus == 2
         assert result[0].total_memory_gb == 0.0
         assert result[0].total_gpus == 0
+        assert result[0].gpu_types == ""
 
     def test_aggregate_user_stats_tres_overrides_node_cpu_estimation(self) -> None:
         """Test that TRES CPU count overrides node-based estimation."""
@@ -313,6 +348,7 @@ class TestUserOverviewTab:
         assert result[0].total_cpus == 64
         assert result[0].total_memory_gb == 512.0
         assert result[0].total_gpus == 16
+        assert result[0].gpu_types == "16x GPU"
 
     def test_aggregate_user_stats_mixed_tres_and_no_tres(self) -> None:
         """Test aggregating stats with mix of jobs with and without TRES."""
@@ -326,3 +362,47 @@ class TestUserOverviewTab:
         assert result[0].total_cpus == 33  # 32 + 1
         assert result[0].total_memory_gb == 256.0  # Only from first job
         assert result[0].total_gpus == 8  # Only from first job
+        assert result[0].gpu_types == "8x GPU"
+
+    def test_aggregate_user_stats_with_gpu_types(self) -> None:
+        """Test aggregating stats with GPU type information."""
+        jobs = [
+            ("12345", "job1", "user1", "RUNNING", "1:00:00", "1", "node01", "cpu=32,mem=256G,node=1,gres/gpu:h200=8"),
+            ("12346", "job2", "user1", "RUNNING", "0:30:00", "1", "node02", "cpu=16,mem=128G,node=1,gres/gpu:h200=4"),
+        ]
+        result = UserOverviewTab.aggregate_user_stats(jobs)
+        assert len(result) == 1
+        assert result[0].total_gpus == 12  # 8 + 4
+        assert result[0].gpu_types == "12x H200"
+
+    def test_aggregate_user_stats_with_multiple_gpu_types(self) -> None:
+        """Test aggregating stats with multiple GPU types."""
+        jobs = [
+            ("12345", "job1", "user1", "RUNNING", "1:00:00", "1", "node01", "cpu=32,mem=256G,node=1,gres/gpu:h200=8"),
+            ("12346", "job2", "user1", "RUNNING", "0:30:00", "1", "node02", "cpu=16,mem=128G,node=1,gres/gpu:a100=4"),
+        ]
+        result = UserOverviewTab.aggregate_user_stats(jobs)
+        assert len(result) == 1
+        assert result[0].total_gpus == 12  # 8 + 4
+        # Should be sorted alphabetically
+        assert result[0].gpu_types == "4x A100, 8x H200"
+
+    def test_aggregate_user_stats_skip_generic_when_specific_types_exist(self) -> None:
+        """Test that generic GPU entries are skipped when specific types exist."""
+        jobs = [
+            # Both generic and specific types in same TRES (should only count specific)
+            (
+                "12345",
+                "job1",
+                "user1",
+                "RUNNING",
+                "1:00:00",
+                "1",
+                "node01",
+                "cpu=32,mem=256G,node=1,gres/gpu=8,gres/gpu:h200=8",
+            ),
+        ]
+        result = UserOverviewTab.aggregate_user_stats(jobs)
+        assert len(result) == 1
+        assert result[0].total_gpus == 8  # Only h200, generic is skipped
+        assert result[0].gpu_types == "8x H200"


### PR DESCRIPTION
- Added gpu_types field to UserStats dataclass
- Enhanced TRES parsing to extract GPU types (generic and typed formats)
- Updated user overview table to display GPU types column
- Modified get_all_users_jobs() to fetch TRES using scontrol (squeue doesn't support TRES in format)
- Added comprehensive tests for GPU type parsing and aggregation
- Fixed issue where users showed 0 GPUs by fetching TRES data separately