### PR TITLE
Add arrow key scrolling for users and logs tabs

### DIFF
--- a/stoei/app.py
+++ b/stoei/app.py
@@ -666,6 +666,14 @@ class SlurmMonitor(App[None]):
             elif event.tab_name == "users":
                 # Always update when switching to users tab
                 self._update_user_overview()
+                # Focus the users table to enable arrow key navigation
+                try:
+                    user_tab = self.query_one("#user-overview", UserOverviewTab)
+                    users_table = user_tab.query_one("#users_table", DataTable)
+                    users_table.focus()
+                    logger.debug("Focused users table for arrow key navigation")
+                except Exception as exc:
+                    logger.debug(f"Failed to focus users table: {exc}")
             elif event.tab_name == "logs":
                 # Focus the log pane when switching to logs tab
                 try:


### PR DESCRIPTION
- Focus users table when switching to users tab to enable arrow key navigation
- Logs tab already has focus set up, enabling arrow key scrolling
- Both tabs now support arrow key navigation for better UX