### PR TITLE
fix: improve editor fallback when $EDITOR is not found

### DIFF
--- a/stoei/editor.py
+++ b/stoei/editor.py
@@ -9,23 +9,28 @@ from stoei.logger import get_logger
 
 logger = get_logger(__name__)
 
-# Default editors to try if $EDITOR is not set
-DEFAULT_EDITORS = ["less", "more", "vim", "nano", "vi", "cat"]
+# Default editors to try if $EDITOR is not set or not found
+# Prioritize vim and nano as they are common interactive editors
+DEFAULT_EDITORS = ["vim", "nano", "vi"]
 
 
 def get_editor() -> str | None:
     """Get the user's preferred editor.
 
     Checks $EDITOR environment variable first, then falls back to common editors.
+    If $EDITOR is set but not found, warns and falls back to vim or nano.
 
     Returns:
         Path to editor executable, or None if no editor found.
     """
     # First check $EDITOR environment variable
     editor = os.environ.get("EDITOR")
-    if editor and shutil.which(editor):
-        logger.debug(f"Using $EDITOR: {editor}")
-        return editor
+    if editor:
+        if shutil.which(editor):
+            logger.debug(f"Using $EDITOR: {editor}")
+            return editor
+        # $EDITOR is set but not found - warn and fall back
+        logger.warning(f"$EDITOR is set to '{editor}' but not found, using fallback editor")
 
     # Fall back to common editors
     for ed in DEFAULT_EDITORS:
@@ -75,7 +80,7 @@ def open_in_editor(filepath: str | None) -> tuple[bool, str]:  # noqa: PLR0911
     # Get editor
     editor = get_editor()
     if not editor:
-        error_msg = "No editor available. Set $EDITOR environment variable."
+        error_msg = "No editor available. Set $EDITOR environment variable or install vim/nano."
         logger.error(error_msg)
         return False, error_msg
 

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -30,9 +30,9 @@ class TestGetEditor:
         ):
             # First call for EDITOR returns None (not found)
             # Second call for first default editor returns path
-            mock_which.side_effect = [None, "/usr/bin/less"]
+            mock_which.side_effect = [None, "/usr/bin/vim"]
             result = get_editor()
-            assert result == "less"
+            assert result == "vim"
 
     def test_uses_first_available_default_editor(self) -> None:
         """Test that first available default editor is used."""
@@ -123,7 +123,7 @@ class TestOpenInEditor:
             success, message = open_in_editor(str(test_file))
             assert success is False
             assert "No editor available" in message
-            assert "$EDITOR" in message
+            assert "$EDITOR" in message or "vim/nano" in message
 
     def test_opens_file_successfully(self, tmp_path: Path) -> None:
         """Test that file is opened successfully in editor."""
@@ -134,17 +134,17 @@ class TestOpenInEditor:
             patch("stoei.editor.get_editor") as mock_get_editor,
             patch("subprocess.run") as mock_run,
         ):
-            mock_get_editor.return_value = "less"
+            mock_get_editor.return_value = "vim"
             mock_run.return_value = MagicMock(returncode=0)
 
             success, message = open_in_editor(str(test_file))
 
             assert success is True
             assert "Opened" in message
-            assert "less" in message
+            assert "vim" in message
             mock_run.assert_called_once()
             call_args = mock_run.call_args
-            assert call_args[0][0] == ["less", str(test_file)]
+            assert call_args[0][0] == ["vim", str(test_file)]
 
     def test_returns_error_when_editor_fails(self, tmp_path: Path) -> None:
         """Test that error is returned when editor exits with non-zero code."""
@@ -155,7 +155,7 @@ class TestOpenInEditor:
             patch("stoei.editor.get_editor") as mock_get_editor,
             patch("subprocess.run") as mock_run,
         ):
-            mock_get_editor.return_value = "less"
+            mock_get_editor.return_value = "vim"
             mock_run.return_value = MagicMock(returncode=1)
 
             success, message = open_in_editor(str(test_file))
@@ -189,7 +189,7 @@ class TestOpenInEditor:
             patch("stoei.editor.get_editor") as mock_get_editor,
             patch("subprocess.run") as mock_run,
         ):
-            mock_get_editor.return_value = "less"
+            mock_get_editor.return_value = "vim"
             mock_run.side_effect = subprocess.SubprocessError("Process error")
 
             success, message = open_in_editor(str(test_file))
@@ -206,7 +206,7 @@ class TestOpenInEditor:
             patch("stoei.editor.get_editor") as mock_get_editor,
             patch("subprocess.run") as mock_run,
         ):
-            mock_get_editor.return_value = "less"
+            mock_get_editor.return_value = "vim"
             mock_run.side_effect = OSError("OS error")
 
             success, message = open_in_editor(str(test_file))


### PR DESCRIPTION
Fixes issue where opening logs in editor does nothing when $EDITOR is set but not found.

- Warn when $EDITOR is set but executable not found
- Default to vim/nano instead of less/more (viewers, not editors)
- Update error message to suggest installing vim/nano
- Update tests to match new default editor priority