### PR TITLE
feat: optimize cluster data loading with loading screen

### DIFF
--- a/stoei/slurm/__init__.py
+++ b/stoei/slurm/__init__.py
@@ -1,7 +1,13 @@
 """SLURM interaction modules."""
 
 from stoei.slurm.cache import Job, JobCache, JobState
-from stoei.slurm.commands import cancel_job, get_job_history, get_job_info, get_running_jobs
+from stoei.slurm.commands import (
+    cancel_job,
+    get_all_running_jobs,
+    get_job_history,
+    get_job_info,
+    get_running_jobs,
+)
 from stoei.slurm.formatters import format_job_info, format_value
 from stoei.slurm.parser import parse_scontrol_output
 from stoei.slurm.validation import get_current_username, validate_job_id, validate_username
@@ -13,6 +19,7 @@ __all__ = [
     "cancel_job",
     "format_job_info",
     "format_value",
+    "get_all_running_jobs",
     "get_current_username",
     "get_job_history",
     "get_job_info",

--- a/stoei/slurm/cache.py
+++ b/stoei/slurm/cache.py
@@ -141,6 +141,29 @@ class JobCache:
         running_jobs = get_running_jobs()
         history_jobs, total_jobs, total_requeues, max_requeues = get_job_history()
 
+        # Build from fetched data
+        self._build_from_data(running_jobs, history_jobs, total_jobs, total_requeues, max_requeues)
+
+    def _build_from_data(
+        self,
+        running_jobs: list[tuple[str, ...]],
+        history_jobs: list[tuple[str, ...]],
+        total_jobs: int,
+        total_requeues: int,
+        max_requeues: int,
+    ) -> None:
+        """Build job cache from pre-fetched data.
+
+        This method is useful when data has already been fetched (e.g., during
+        step-by-step loading) to avoid duplicate SLURM command calls.
+
+        Args:
+            running_jobs: List of running/pending job tuples from squeue.
+            history_jobs: List of historical job tuples from sacct.
+            total_jobs: Total number of jobs in history.
+            total_requeues: Total number of job requeues.
+            max_requeues: Maximum requeues for any single job.
+        """
         # Build job list
         jobs: list[Job] = []
         running_job_ids: set[str] = set()
@@ -203,7 +226,7 @@ class JobCache:
             self._running_count = running_count
             self._pending_count = pending_count
 
-        logger.debug(f"Cache refreshed: {len(jobs)} jobs ({running_count} running, {pending_count} pending)")
+        logger.debug(f"Cache built: {len(jobs)} jobs ({running_count} running, {pending_count} pending)")
 
     @property
     def jobs(self) -> list[Job]:

--- a/stoei/widgets/__init__.py
+++ b/stoei/widgets/__init__.py
@@ -2,6 +2,7 @@
 
 from stoei.widgets.cluster_sidebar import ClusterSidebar, ClusterStats
 from stoei.widgets.job_stats import JobStats
+from stoei.widgets.loading_screen import LoadingScreen, LoadingStep
 from stoei.widgets.log_pane import LogPane
 from stoei.widgets.node_overview import NodeInfo, NodeOverviewTab
 from stoei.widgets.screens import CancelConfirmScreen, JobInfoScreen, JobInputScreen
@@ -15,6 +16,8 @@ __all__ = [
     "JobInfoScreen",
     "JobInputScreen",
     "JobStats",
+    "LoadingScreen",
+    "LoadingStep",
     "LogPane",
     "NodeInfo",
     "NodeOverviewTab",

--- a/stoei/widgets/loading_screen.py
+++ b/stoei/widgets/loading_screen.py
@@ -1,0 +1,317 @@
+"""Loading screen widget with progress bar and step logging."""
+
+import time
+from dataclasses import dataclass
+from typing import ClassVar
+
+from textual.app import ComposeResult
+from textual.containers import Container, VerticalScroll
+from textual.screen import Screen
+from textual.timer import Timer
+from textual.widgets import Label, ProgressBar, Static
+
+from stoei.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass
+class LoadingStep:
+    """A single loading step."""
+
+    name: str
+    description: str
+    weight: float = 1.0  # Relative weight for progress calculation
+
+
+class LoadingScreen(Screen[None]):
+    """Loading screen with progress bar, animation, and step logging.
+
+    Shows:
+    - Animated spinner to confirm app isn't stalled
+    - Progress bar showing overall loading progress
+    - Current step description
+    - Log of completed steps with timing
+    """
+
+    DEFAULT_CSS: ClassVar[str] = """
+    LoadingScreen {
+        align: center middle;
+        background: #0d1117;
+    }
+
+    #loading-container {
+        width: 80%;
+        max-width: 80;
+        height: auto;
+        max-height: 90%;
+        background: #161b22;
+        border: heavy #58a6ff;
+        padding: 2;
+    }
+
+    #loading-title {
+        text-align: center;
+        text-style: bold;
+        margin-bottom: 1;
+        color: #79c0ff;
+    }
+
+    #spinner-container {
+        height: 3;
+        align: center middle;
+        margin-bottom: 1;
+    }
+
+    #spinner {
+        text-align: center;
+        text-style: bold;
+        color: #a371f7;
+    }
+
+    #current-step {
+        text-align: center;
+        margin-bottom: 1;
+        color: #c9d1d9;
+    }
+
+    #progress-bar {
+        margin-bottom: 1;
+        color: #238636;
+        background: #21262d;
+    }
+
+    #progress-label {
+        text-align: center;
+        margin-bottom: 1;
+        color: #8b949e;
+    }
+
+    #step-log-container {
+        height: 12;
+        border: round #30363d;
+        padding: 0 1;
+        margin-top: 1;
+        background: #0d1117;
+    }
+
+    #step-log-title {
+        text-style: bold;
+        margin-bottom: 0;
+        color: #58a6ff;
+    }
+
+    #step-log {
+        height: 100%;
+        scrollbar-gutter: stable;
+        color: #c9d1d9;
+    }
+
+    .step-entry {
+        margin: 0;
+    }
+
+    .step-completed {
+        color: #3fb950;
+    }
+
+    .step-in-progress {
+        color: #d29922;
+    }
+
+    .step-error {
+        color: #f85149;
+    }
+    """
+
+    SPINNER_FRAMES: ClassVar[tuple[str, ...]] = (
+        "⠋",
+        "⠙",
+        "⠹",
+        "⠸",
+        "⠼",
+        "⠴",
+        "⠦",
+        "⠧",
+        "⠇",
+        "⠏",
+    )
+
+    def __init__(
+        self,
+        steps: list[LoadingStep],
+        *,
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+    ) -> None:
+        """Initialize the loading screen.
+
+        Args:
+            steps: List of loading steps to display.
+            name: The name of the screen.
+            id: The ID of the screen.
+            classes: CSS classes for the screen.
+        """
+        super().__init__(name=name, id=id, classes=classes)
+        self.steps = steps
+        self.total_weight = sum(step.weight for step in steps)
+        self._current_step_index = 0
+        self._completed_weight = 0.0
+        self._spinner_frame = 0
+        self._spinner_timer: Timer | None = None
+        self._step_start_times: dict[int, float] = {}
+        self._step_log_entries: list[str] = []
+
+    def compose(self) -> ComposeResult:
+        """Create the loading screen layout."""
+        with Container(id="loading-container"):
+            yield Label("[bold #79c0ff]🚀 STOEI Loading[/bold #79c0ff]", id="loading-title")
+
+            with Container(id="spinner-container"):
+                yield Static(self.SPINNER_FRAMES[0], id="spinner")
+
+            yield Label("Initializing...", id="current-step")
+            yield ProgressBar(id="progress-bar", total=100, show_eta=False)
+            yield Label("0%", id="progress-label")
+
+            yield Label("[bold #58a6ff]Loading Steps:[/bold #58a6ff]", id="step-log-title")
+            with VerticalScroll(id="step-log-container"):
+                yield Static("", id="step-log")
+
+    def on_mount(self) -> None:
+        """Start the spinner animation."""
+        self._start_time = time.time()
+        self._spinner_timer = self.set_interval(0.1, self._animate_spinner)
+        logger.info("Loading screen mounted")
+
+    def _animate_spinner(self) -> None:
+        """Animate the spinner."""
+        self._spinner_frame = (self._spinner_frame + 1) % len(self.SPINNER_FRAMES)
+        try:
+            spinner = self.query_one("#spinner", Static)
+            spinner.update(f"[bold #a371f7]{self.SPINNER_FRAMES[self._spinner_frame]}[/bold #a371f7] Loading...")
+        except Exception as exc:
+            logger.debug(f"Spinner update failed: {exc}")
+
+    def start_step(self, step_index: int) -> None:
+        """Mark a step as starting.
+
+        Args:
+            step_index: Index of the step starting.
+        """
+        if step_index >= len(self.steps):
+            return
+
+        self._current_step_index = step_index
+        self._step_start_times[step_index] = time.time()
+
+        step = self.steps[step_index]
+        logger.info(f"Loading step {step_index + 1}/{len(self.steps)}: {step.name}")
+
+        # Update UI
+        try:
+            current_step_label = self.query_one("#current-step", Label)
+            current_step_label.update(f"[#d29922]●[/#d29922] {step.description}")
+
+            # Add to log
+            self._add_log_entry(f"[#d29922]▶[/#d29922] {step.name}...")
+        except Exception as exc:
+            logger.debug(f"Failed to update loading UI: {exc}")
+
+    def complete_step(self, step_index: int, message: str | None = None) -> None:
+        """Mark a step as completed.
+
+        Args:
+            step_index: Index of the completed step.
+            message: Optional completion message with details.
+        """
+        if step_index >= len(self.steps):
+            return
+
+        step = self.steps[step_index]
+        elapsed = 0.0
+        if step_index in self._step_start_times:
+            elapsed = time.time() - self._step_start_times[step_index]
+
+        self._completed_weight += step.weight
+        progress_pct = (self._completed_weight / self.total_weight) * 100
+
+        detail = f" ({message})" if message else ""
+        logger.info(f"Completed step {step_index + 1}: {step.name}{detail} in {elapsed:.2f}s")
+
+        # Update UI
+        try:
+            progress_bar = self.query_one("#progress-bar", ProgressBar)
+            progress_bar.update(progress=progress_pct)
+
+            progress_label = self.query_one("#progress-label", Label)
+            progress_label.update(f"{progress_pct:.0f}%")
+
+            # Update log with completion
+            time_str = f"[#8b949e]{elapsed:.1f}s[/#8b949e]"
+            detail_str = f" - [#8b949e]{message}[/#8b949e]" if message else ""
+            self._add_log_entry(f"[#3fb950]✓[/#3fb950] {step.name}{detail_str} {time_str}")
+        except Exception as exc:
+            logger.debug(f"Failed to update loading UI: {exc}")
+
+    def fail_step(self, step_index: int, error: str) -> None:
+        """Mark a step as failed.
+
+        Args:
+            step_index: Index of the failed step.
+            error: Error message.
+        """
+        if step_index >= len(self.steps):
+            return
+
+        step = self.steps[step_index]
+        logger.error(f"Failed step {step_index + 1}: {step.name} - {error}")
+
+        # Update log with failure
+        try:
+            self._add_log_entry(f"[#f85149]✗[/#f85149] {step.name}: [#f85149]{error}[/#f85149]")
+        except Exception as exc:
+            logger.debug(f"Failed to update loading UI: {exc}")
+
+    def _add_log_entry(self, entry: str) -> None:
+        """Add an entry to the step log.
+
+        Args:
+            entry: Log entry with Rich markup.
+        """
+        self._step_log_entries.append(entry)
+
+        try:
+            step_log = self.query_one("#step-log", Static)
+            step_log.update("\n".join(self._step_log_entries))
+
+            # Scroll to bottom
+            scroll_container = self.query_one("#step-log-container", VerticalScroll)
+            scroll_container.scroll_end(animate=False)
+        except Exception as exc:
+            logger.debug(f"Failed to update step log: {exc}")
+
+    def set_complete(self) -> None:
+        """Mark loading as fully complete."""
+        total_time = time.time() - self._start_time
+        logger.info(f"Loading complete in {total_time:.2f}s")
+
+        try:
+            current_step_label = self.query_one("#current-step", Label)
+            current_step_label.update("[#3fb950]✓[/#3fb950] Loading complete!")
+
+            progress_bar = self.query_one("#progress-bar", ProgressBar)
+            progress_bar.update(progress=100)
+
+            progress_label = self.query_one("#progress-label", Label)
+            progress_label.update(f"[#3fb950]100%[/#3fb950] - {total_time:.1f}s total")
+
+            spinner = self.query_one("#spinner", Static)
+            spinner.update("[bold #3fb950]✓[/bold #3fb950] Ready!")
+        except Exception as exc:
+            logger.debug(f"Failed to update loading UI: {exc}")
+
+        # Stop spinner
+        if self._spinner_timer:
+            self._spinner_timer.stop()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -155,23 +155,31 @@ class TestRefreshDataAsync:
         # The method should NOT be a coroutine function
         assert not inspect.iscoroutinefunction(app._refresh_data_async)
 
-    def test_refresh_data_calls_cache_refresh(self) -> None:
-        """Verify that _refresh_data_async calls the cache refresh."""
+    def test_refresh_data_calls_cache_build(self) -> None:
+        """Verify that _refresh_data_async calls the cache _build_from_data."""
         app = SlurmMonitor()
 
         with (
-            patch.object(app._job_cache, "refresh") as mock_refresh,
+            patch("stoei.app.get_running_jobs", return_value=[]),
+            patch("stoei.app.get_job_history", return_value=([], 0, 0, 0)),
+            patch("stoei.app.get_cluster_nodes", return_value=([], None)),
+            patch("stoei.app.get_all_running_jobs", return_value=[]),
+            patch.object(app._job_cache, "_build_from_data") as mock_build,
             patch.object(app, "call_from_thread"),
         ):
             app._refresh_data_async()
-            mock_refresh.assert_called_once()
+            mock_build.assert_called_once()
 
     def test_refresh_data_schedules_ui_update(self) -> None:
         """Verify that _refresh_data_async schedules UI update on main thread."""
         app = SlurmMonitor()
 
         with (
-            patch.object(app._job_cache, "refresh"),
+            patch("stoei.app.get_running_jobs", return_value=[]),
+            patch("stoei.app.get_job_history", return_value=([], 0, 0, 0)),
+            patch("stoei.app.get_cluster_nodes", return_value=([], None)),
+            patch("stoei.app.get_all_running_jobs", return_value=[]),
+            patch.object(app._job_cache, "_build_from_data"),
             patch.object(app, "call_from_thread") as mock_call_from_thread,
         ):
             app._refresh_data_async()
@@ -184,23 +192,28 @@ class TestRefreshDataAsync:
         app = SlurmMonitor()
 
         with (
-            patch.object(app._job_cache, "refresh"),
+            patch("stoei.app.get_running_jobs", return_value=[]),
+            patch("stoei.app.get_job_history", return_value=([], 0, 0, 0)),
             patch("stoei.app.get_cluster_nodes", return_value=([], None)) as mock_get_nodes,
+            patch("stoei.app.get_all_running_jobs", return_value=[]),
+            patch.object(app._job_cache, "_build_from_data"),
             patch.object(app, "call_from_thread"),
         ):
             app._refresh_data_async()
             mock_get_nodes.assert_called_once()
 
     def test_refresh_data_fetches_all_users_jobs(self) -> None:
-        """Verify that _refresh_data_async fetches all users jobs."""
+        """Verify that _refresh_data_async fetches all running jobs."""
         from unittest.mock import patch
 
         app = SlurmMonitor()
 
         with (
-            patch.object(app._job_cache, "refresh"),
+            patch("stoei.app.get_running_jobs", return_value=[]),
+            patch("stoei.app.get_job_history", return_value=([], 0, 0, 0)),
             patch("stoei.app.get_cluster_nodes", return_value=([], None)),
-            patch("stoei.app.get_all_users_jobs", return_value=[]) as mock_get_jobs,
+            patch("stoei.app.get_all_running_jobs", return_value=[]) as mock_get_jobs,
+            patch.object(app._job_cache, "_build_from_data"),
             patch.object(app, "call_from_thread"),
         ):
             app._refresh_data_async()
@@ -213,9 +226,11 @@ class TestRefreshDataAsync:
         app = SlurmMonitor()
 
         with (
-            patch.object(app._job_cache, "refresh"),
+            patch("stoei.app.get_running_jobs", return_value=[]),
+            patch("stoei.app.get_job_history", return_value=([], 0, 0, 0)),
             patch("stoei.app.get_cluster_nodes", return_value=([], "Error message")),
-            patch("stoei.app.get_all_users_jobs", return_value=[]),
+            patch("stoei.app.get_all_running_jobs", return_value=[]),
+            patch.object(app._job_cache, "_build_from_data"),
             patch.object(app, "call_from_thread"),
         ):
             # Should not raise an error

--- a/tests/test_app_cluster.py
+++ b/tests/test_app_cluster.py
@@ -163,9 +163,11 @@ class TestAppClusterIntegration:
     def test_app_refresh_fetches_cluster_data(self, app: SlurmMonitor) -> None:
         """Test that app refresh fetches cluster data."""
         with (
-            patch.object(app._job_cache, "refresh"),
+            patch("stoei.app.get_running_jobs", return_value=[]),
+            patch("stoei.app.get_job_history", return_value=([], 0, 0, 0)),
             patch("stoei.app.get_cluster_nodes", return_value=([{"NodeName": "node01"}], None)) as mock_nodes,
-            patch("stoei.app.get_all_users_jobs", return_value=[]) as mock_jobs,
+            patch("stoei.app.get_all_running_jobs", return_value=[]) as mock_jobs,
+            patch.object(app._job_cache, "_build_from_data"),
             patch.object(app, "call_from_thread"),
         ):
             app._refresh_data_async()
@@ -175,9 +177,11 @@ class TestAppClusterIntegration:
     def test_app_handles_cluster_nodes_error(self, app: SlurmMonitor) -> None:
         """Test that app handles cluster nodes fetch errors."""
         with (
-            patch.object(app._job_cache, "refresh"),
+            patch("stoei.app.get_running_jobs", return_value=[]),
+            patch("stoei.app.get_job_history", return_value=([], 0, 0, 0)),
             patch("stoei.app.get_cluster_nodes", return_value=([], "Error fetching nodes")),
-            patch("stoei.app.get_all_users_jobs", return_value=[]),
+            patch("stoei.app.get_all_running_jobs", return_value=[]),
+            patch.object(app._job_cache, "_build_from_data"),
             patch.object(app, "call_from_thread"),
         ):
             app._refresh_data_async()

--- a/tests/test_widgets/test_loading_screen.py
+++ b/tests/test_widgets/test_loading_screen.py
@@ -1,0 +1,121 @@
+"""Tests for the LoadingScreen widget."""
+
+import pytest
+from stoei.widgets.loading_screen import LoadingScreen, LoadingStep
+
+
+class TestLoadingStep:
+    """Tests for the LoadingStep dataclass."""
+
+    def test_loading_step_creation(self) -> None:
+        """Test creating a LoadingStep with basic parameters."""
+        step = LoadingStep("test_step", "Test description")
+        assert step.name == "test_step"
+        assert step.description == "Test description"
+        assert step.weight == 1.0  # Default weight
+
+    def test_loading_step_with_custom_weight(self) -> None:
+        """Test creating a LoadingStep with custom weight."""
+        step = LoadingStep("heavy_step", "Heavy operation", weight=3.0)
+        assert step.name == "heavy_step"
+        assert step.description == "Heavy operation"
+        assert step.weight == 3.0
+
+
+class TestLoadingScreen:
+    """Tests for the LoadingScreen widget."""
+
+    @pytest.fixture
+    def steps(self) -> list[LoadingStep]:
+        """Create a list of loading steps for testing."""
+        return [
+            LoadingStep("step1", "Step 1 description", weight=1.0),
+            LoadingStep("step2", "Step 2 description", weight=2.0),
+            LoadingStep("step3", "Step 3 description", weight=1.0),
+        ]
+
+    def test_loading_screen_initialization(self, steps: list[LoadingStep]) -> None:
+        """Test LoadingScreen initialization."""
+        screen = LoadingScreen(steps)
+        assert screen.steps == steps
+        assert screen.total_weight == 4.0  # 1.0 + 2.0 + 1.0
+        assert screen._current_step_index == 0
+        assert screen._completed_weight == 0.0
+        assert screen._spinner_frame == 0
+        assert screen._spinner_timer is None
+
+    def test_loading_screen_total_weight_calculation(self) -> None:
+        """Test that total weight is calculated correctly."""
+        steps = [
+            LoadingStep("a", "A", weight=0.5),
+            LoadingStep("b", "B", weight=1.5),
+            LoadingStep("c", "C", weight=2.0),
+        ]
+        screen = LoadingScreen(steps)
+        assert screen.total_weight == 4.0
+
+    def test_loading_screen_with_empty_steps(self) -> None:
+        """Test LoadingScreen with empty steps list."""
+        screen = LoadingScreen([])
+        assert screen.steps == []
+        assert screen.total_weight == 0.0
+
+    def test_spinner_frames_exist(self) -> None:
+        """Test that spinner frames are defined."""
+        assert len(LoadingScreen.SPINNER_FRAMES) > 0
+        # All frames should be non-empty strings
+        for frame in LoadingScreen.SPINNER_FRAMES:
+            assert isinstance(frame, str)
+            assert len(frame) > 0
+
+    def test_loading_screen_has_default_css(self) -> None:
+        """Test that LoadingScreen has DEFAULT_CSS defined."""
+        assert LoadingScreen.DEFAULT_CSS is not None
+        assert "LoadingScreen" in LoadingScreen.DEFAULT_CSS
+        assert "#loading-container" in LoadingScreen.DEFAULT_CSS
+        assert "#spinner" in LoadingScreen.DEFAULT_CSS
+        assert "#progress-bar" in LoadingScreen.DEFAULT_CSS
+
+    def test_loading_screen_step_log_tracking(self, steps: list[LoadingStep]) -> None:
+        """Test that step log entries are tracked."""
+        screen = LoadingScreen(steps)
+        assert screen._step_log_entries == []
+
+    def test_loading_screen_step_start_times_tracking(self, steps: list[LoadingStep]) -> None:
+        """Test that step start times are tracked."""
+        screen = LoadingScreen(steps)
+        assert screen._step_start_times == {}
+
+
+class TestLoadingScreenMethods:
+    """Tests for LoadingScreen methods that don't require mounting."""
+
+    @pytest.fixture
+    def screen(self) -> LoadingScreen:
+        """Create a LoadingScreen for testing."""
+        steps = [
+            LoadingStep("step1", "Step 1", weight=1.0),
+            LoadingStep("step2", "Step 2", weight=1.0),
+        ]
+        return LoadingScreen(steps)
+
+    def test_start_step_out_of_range(self, screen: LoadingScreen) -> None:
+        """Test start_step with index out of range."""
+        # This should not raise, just return early
+        screen.start_step(999)
+        assert screen._current_step_index == 0
+
+    def test_complete_step_out_of_range(self, screen: LoadingScreen) -> None:
+        """Test complete_step with index out of range."""
+        initial_weight = screen._completed_weight
+        # This should not raise, just return early
+        screen.complete_step(999)
+        assert screen._completed_weight == initial_weight
+
+    def test_fail_step_out_of_range(self, screen: LoadingScreen) -> None:
+        """Test fail_step with index out of range."""
+        initial_entries = len(screen._step_log_entries)
+        # This should not raise, just return early
+        screen.fail_step(999, "error")
+        # No log entry should be added since step is out of range
+        assert len(screen._step_log_entries) == initial_entries


### PR DESCRIPTION
- Replace O(n) scontrol calls with single squeue -O command for TRES data
- Add LoadingScreen widget with progress bar, spinner, and step logging
- Reduce job history from 30 days to 7 days for faster loading
- Only fetch RUNNING jobs from other users (not PENDING)
- Add step-by-step initial loading with 9 discrete progress steps
- Use modern GitHub-inspired dark color scheme for loading screen
- Add _build_from_data() to JobCache to avoid duplicate SLURM calls