### PR TITLE
feat: break down pending queue by partition

### DIFF
--- a/stoei/slurm/commands.py
+++ b/stoei/slurm/commands.py
@@ -565,14 +565,15 @@ def get_node_info(node_name: str) -> tuple[str, str | None]:
 
 
 # Fixed-width column positions for squeue -O format
-# Format: JobID:20,Name:20,UserName:15,StateCompact:10,TimeUsed:12,NumNodes:6,NodeList:30,tres:80
+# Format: JobID:20,Name:20,UserName:15,Partition:15,StateCompact:10,TimeUsed:12,NumNodes:6,NodeList:30,tres:80
 _SQUEUE_COL_JOBID_END = 20
 _SQUEUE_COL_NAME_END = 40
 _SQUEUE_COL_USER_END = 55
-_SQUEUE_COL_STATE_END = 65
-_SQUEUE_COL_TIME_END = 77
-_SQUEUE_COL_NODES_END = 83
-_SQUEUE_COL_NODELIST_END = 113
+_SQUEUE_COL_PARTITION_END = 70
+_SQUEUE_COL_STATE_END = 80
+_SQUEUE_COL_TIME_END = 92
+_SQUEUE_COL_NODES_END = 98
+_SQUEUE_COL_NODELIST_END = 128
 
 
 def _parse_fixed_width_squeue_line(line: str) -> tuple[str, ...] | None:
@@ -582,7 +583,7 @@ def _parse_fixed_width_squeue_line(line: str) -> tuple[str, ...] | None:
         line: Single line from squeue -O output.
 
     Returns:
-        Tuple of (job_id, name, user, state, time_used, num_nodes, node_list, tres) or None.
+        Tuple of (job_id, name, user, partition, state, time_used, num_nodes, node_list, tres) or None.
     """
     if len(line) < _SQUEUE_COL_JOBID_END:
         return None
@@ -593,7 +594,10 @@ def _parse_fixed_width_squeue_line(line: str) -> tuple[str, ...] | None:
 
     name = line[_SQUEUE_COL_JOBID_END:_SQUEUE_COL_NAME_END].strip() if len(line) > _SQUEUE_COL_JOBID_END else ""
     user = line[_SQUEUE_COL_NAME_END:_SQUEUE_COL_USER_END].strip() if len(line) > _SQUEUE_COL_NAME_END else ""
-    state = line[_SQUEUE_COL_USER_END:_SQUEUE_COL_STATE_END].strip() if len(line) > _SQUEUE_COL_USER_END else ""
+    partition = line[_SQUEUE_COL_USER_END:_SQUEUE_COL_PARTITION_END].strip() if len(line) > _SQUEUE_COL_USER_END else ""
+    state = (
+        line[_SQUEUE_COL_PARTITION_END:_SQUEUE_COL_STATE_END].strip() if len(line) > _SQUEUE_COL_PARTITION_END else ""
+    )
     time_used = line[_SQUEUE_COL_STATE_END:_SQUEUE_COL_TIME_END].strip() if len(line) > _SQUEUE_COL_STATE_END else ""
     num_nodes = line[_SQUEUE_COL_TIME_END:_SQUEUE_COL_NODES_END].strip() if len(line) > _SQUEUE_COL_TIME_END else ""
     node_list = (
@@ -601,7 +605,7 @@ def _parse_fixed_width_squeue_line(line: str) -> tuple[str, ...] | None:
     )
     tres = line[_SQUEUE_COL_NODELIST_END:].strip() if len(line) > _SQUEUE_COL_NODELIST_END else ""
 
-    return (job_id, name, user, state, time_used, num_nodes, node_list, tres)
+    return (job_id, name, user, partition, state, time_used, num_nodes, node_list, tres)
 
 
 def get_all_running_jobs() -> tuple[list[tuple[str, ...]], str | None]:
@@ -620,7 +624,7 @@ def get_all_running_jobs() -> tuple[list[tuple[str, ...]], str | None]:
         command = [
             squeue,
             "-O",
-            "JobID:20,Name:20,UserName:15,StateCompact:10,TimeUsed:12,NumNodes:6,NodeList:30,tres:80",
+            "JobID:20,Name:20,UserName:15,Partition:15,StateCompact:10,TimeUsed:12,NumNodes:6,NodeList:30,tres:80",
             "-a",  # Show all partitions
             "-t",
             "RUNNING,PENDING",

--- a/stoei/widgets/cluster_sidebar.py
+++ b/stoei/widgets/cluster_sidebar.py
@@ -3,10 +3,37 @@
 from dataclasses import dataclass, field
 from typing import ClassVar
 
+from textual.app import ComposeResult
+from textual.containers import VerticalScroll
 from textual.widgets import Static
 
 # Conversion constant: 1 TB = 1024 GB
 GB_PER_TB = 1024
+
+
+def format_memory_gb(memory_gb: float) -> str:
+    """Format a memory quantity in GB into a display string.
+
+    Args:
+        memory_gb: Memory in gigabytes.
+
+    Returns:
+        Human-friendly string in GB or TB.
+    """
+    if memory_gb >= GB_PER_TB:
+        return f"{memory_gb / GB_PER_TB:.1f} TB"
+    return f"{memory_gb:.1f} GB"
+
+
+@dataclass
+class PendingPartitionStats:
+    """Aggregated pending resources for a single partition."""
+
+    jobs_count: int = 0
+    cpus: int = 0
+    memory_gb: float = 0.0
+    gpus: int = 0
+    gpus_by_type: dict[str, int] = field(default_factory=dict)
 
 
 @dataclass
@@ -29,6 +56,7 @@ class ClusterStats:
     pending_memory_gb: float = 0.0
     pending_gpus: int = 0
     pending_gpus_by_type: dict[str, int] = field(default_factory=dict)
+    pending_by_partition: dict[str, PendingPartitionStats] = field(default_factory=dict)
 
     @property
     def free_nodes_pct(self) -> float:
@@ -75,8 +103,8 @@ class ClusterStats:
         return ((total - allocated) / total) * 100.0
 
 
-class ClusterSidebar(Static):
-    """Widget to display cluster load statistics in a sidebar."""
+class ClusterSidebar(VerticalScroll):
+    """Scrollable widget to display cluster load statistics in a sidebar."""
 
     DEFAULT_CSS: ClassVar[str] = """
     ClusterSidebar {
@@ -84,6 +112,17 @@ class ClusterSidebar(Static):
         border: heavy $accent;
         background: $panel;
         padding: 1;
+        scrollbar-gutter: stable;
+        scrollbar-size: 1 1;
+        scrollbar-background: $panel;
+        scrollbar-color: $border;
+        scrollbar-color-hover: $accent-hover;
+        scrollbar-color-active: $accent;
+    }
+
+    #cluster-sidebar-content {
+        width: 100%;
+        height: auto;
     }
     """
 
@@ -103,11 +142,16 @@ class ClusterSidebar(Static):
             classes: The CSS classes for the widget.
             disabled: Whether the widget is disabled.
         """
-        # Initialize with loading message (use bright_black instead of dim for better compatibility)
-        loading_msg = "[bold]Cluster Load[/bold]\n\n[bright_black]Loading cluster data...[/bright_black]"
-        super().__init__(loading_msg, name=name, id=id, classes=classes, disabled=disabled)
+        super().__init__(name=name, id=id, classes=classes, disabled=disabled)
         self.stats: ClusterStats = ClusterStats()
         self._data_loaded: bool = False
+        self._content_markup: str = "[bold]Cluster Load[/bold]\n\n[bright_black]Loading cluster data...[/bright_black]"
+        self._content_widget: Static | None = None
+
+    def compose(self) -> ComposeResult:
+        """Compose the scrollable content."""
+        self._content_widget = Static(self._content_markup, id="cluster-sidebar-content")
+        yield self._content_widget
 
     def update_stats(self, stats: ClusterStats) -> None:
         """Update the cluster statistics display.
@@ -117,7 +161,72 @@ class ClusterSidebar(Static):
         """
         self.stats = stats
         self._data_loaded = True
-        self.update(self._render_stats())
+        self._content_markup = self._render_stats()
+        if self._content_widget is not None:
+            self._content_widget.update(self._content_markup)
+
+    @staticmethod
+    def _color_pct(pct: float, *, green_threshold: float = 50.0, yellow_threshold: float = 25.0) -> str:
+        """Color code a percentage with Rich markup."""
+        if pct >= green_threshold:
+            return f"[green]{pct:.1f}%[/green]"
+        if pct >= yellow_threshold:
+            return f"[yellow]{pct:.1f}%[/yellow]"
+        return f"[red]{pct:.1f}%[/red]"
+
+    def _append_gpu_section(self, lines: list[str], stats: ClusterStats, *, gpus_pct: float | None) -> None:
+        """Append the GPU section to the sidebar output."""
+        if stats.gpus_by_type:
+            lines.append("")
+            lines.append("[bold]GPUs:[/bold]")
+            # Sort by type name for consistent display
+            for gpu_type in sorted(stats.gpus_by_type.keys()):
+                total, allocated = stats.gpus_by_type[gpu_type]
+                free_pct = stats.get_gpu_type_free_pct(gpu_type)
+                type_display = gpu_type if gpu_type != "gpu" else "generic"
+                lines.append(f"  {type_display}: {allocated}/{total} ({self._color_pct(free_pct)})")
+            return
+
+        if stats.total_gpus > 0 and gpus_pct is not None:
+            free_gpus = stats.total_gpus - stats.allocated_gpus
+            lines.extend(
+                [
+                    "",
+                    "[bold]GPUs:[/bold]",
+                    f"  Total: {stats.total_gpus}",
+                    f"  Free: {free_gpus} ({self._color_pct(gpus_pct)})",
+                ]
+            )
+
+    def _append_pending_queue_section(self, lines: list[str], stats: ClusterStats) -> None:
+        """Append the pending queue section to the sidebar output."""
+        if stats.pending_jobs_count <= 0:
+            return
+
+        lines.append("")
+        lines.append("[bold]Pending Queue[/bold]")
+
+        if not stats.pending_by_partition:
+            lines.append("  (No partition breakdown available)")
+            return
+
+        for partition, pstats in sorted(stats.pending_by_partition.items(), key=lambda item: item[0].casefold()):
+            part_name = partition or "unknown"
+            lines.append(f"  {part_name}: {pstats.jobs_count} jobs")
+
+            if pstats.cpus > 0:
+                lines.append(f"    CPUs: {pstats.cpus:,}")
+            if pstats.memory_gb > 0:
+                lines.append(f"    Memory: {format_memory_gb(pstats.memory_gb)}")
+
+            if pstats.gpus_by_type:
+                lines.append("    GPUs:")
+                for gpu_type in sorted(pstats.gpus_by_type.keys()):
+                    gpu_count = pstats.gpus_by_type[gpu_type]
+                    type_display = gpu_type if gpu_type != "gpu" else "generic"
+                    lines.append(f"      {type_display}: {gpu_count}")
+            elif pstats.gpus > 0:
+                lines.append(f"    GPUs: {pstats.gpus}")
 
     def _render_stats(self) -> str:
         """Render the statistics as a string.
@@ -133,20 +242,6 @@ class ClusterSidebar(Static):
         memory_pct = stats.free_memory_pct
         gpus_pct = stats.free_gpus_pct if stats.total_gpus > 0 else None
 
-        # Color coding based on availability
-        # Thresholds for color coding: green >= 50%, yellow >= 25%, red < 25%
-        green_threshold = 50.0
-        yellow_threshold = 25.0
-
-        def color_pct(pct: float) -> str:
-            """Color code percentage."""
-            if pct >= green_threshold:
-                return f"[green]{pct:.1f}%[/green]"
-            elif pct >= yellow_threshold:
-                return f"[yellow]{pct:.1f}%[/yellow]"
-            else:
-                return f"[red]{pct:.1f}%[/red]"
-
         # Handle case where data hasn't been loaded yet
         if not self._data_loaded:
             return "[bold]Cluster Load[/bold]\n\n[bright_black]Loading cluster data...[/bright_black]"
@@ -155,60 +250,19 @@ class ClusterSidebar(Static):
             "[bold]Cluster Load[/bold]",
             "",
             "[bold]Nodes:[/bold]",
-            f"  Free: {color_pct(nodes_pct)}",
+            f"  Free: {self._color_pct(nodes_pct)}",
             f"  {stats.free_nodes}/{stats.total_nodes} available",
             "",
             "[bold]CPUs:[/bold]",
-            f"  Free: {color_pct(cpus_pct)}",
+            f"  Free: {self._color_pct(cpus_pct)}",
             f"  {stats.total_cpus - stats.allocated_cpus}/{stats.total_cpus} available",
             "",
             "[bold]Memory:[/bold]",
-            f"  Free: {color_pct(memory_pct)}",
+            f"  Free: {self._color_pct(memory_pct)}",
             f"  {stats.total_memory_gb - stats.allocated_memory_gb:.1f}/{stats.total_memory_gb:.1f} GB",
         ]
 
-        # Display GPUs by type if available
-        if stats.gpus_by_type:
-            lines.append("")
-            lines.append("[bold]GPUs:[/bold]")
-            # Sort by type name for consistent display
-            for gpu_type in sorted(stats.gpus_by_type.keys()):
-                total, allocated = stats.gpus_by_type[gpu_type]
-                free_pct = stats.get_gpu_type_free_pct(gpu_type)
-                type_display = gpu_type if gpu_type != "gpu" else "generic"
-                lines.append(f"  {type_display}: {allocated}/{total} ({color_pct(free_pct)})")
-        elif stats.total_gpus > 0 and gpus_pct is not None:
-            # Fallback to old format if no type-specific data
-            free_gpus = stats.total_gpus - stats.allocated_gpus
-            lines.extend(
-                [
-                    "",
-                    "[bold]GPUs:[/bold]",
-                    f"  Total: {stats.total_gpus}",
-                    f"  Free: {free_gpus} ({color_pct(gpus_pct)})",
-                ]
-            )
-
-        # Display pending queue section if there are pending jobs
-        if stats.pending_jobs_count > 0:
-            lines.append("")
-            lines.append("[bold]Pending Queue[/bold]")
-            lines.append(f"  {stats.pending_jobs_count} jobs waiting")
-            lines.append(f"  CPUs: {stats.pending_cpus:,}")
-            # Format memory with appropriate unit
-            pending_mem = stats.pending_memory_gb
-            if pending_mem >= GB_PER_TB:
-                lines.append(f"  Memory: {pending_mem / GB_PER_TB:.1f} TB")
-            else:
-                lines.append(f"  Memory: {pending_mem:.1f} GB")
-            # Display pending GPUs by type if available
-            if stats.pending_gpus_by_type:
-                lines.append("  GPUs:")
-                for gpu_type in sorted(stats.pending_gpus_by_type.keys()):
-                    gpu_count = stats.pending_gpus_by_type[gpu_type]
-                    type_display = gpu_type if gpu_type != "gpu" else "generic"
-                    lines.append(f"    {type_display}: {gpu_count}")
-            elif stats.pending_gpus > 0:
-                lines.append(f"  GPUs: {stats.pending_gpus}")
+        self._append_gpu_section(lines, stats, gpus_pct=gpus_pct)
+        self._append_pending_queue_section(lines, stats)
 
         return "\n".join(lines)

--- a/stoei/widgets/screens.py
+++ b/stoei/widgets/screens.py
@@ -445,8 +445,10 @@ class LogViewerScreen(Screen[None]):
             if self._spinner_timer:
                 self._spinner_timer.stop()
                 self._spinner_timer = None
-            # Update UI - we're already on the main event loop
-            self._on_load_complete()
+            # Update UI after next refresh to ensure widgets are mounted.
+            # This avoids races where the worker completes before the DOM is ready,
+            # which can leave the content scroll container hidden.
+            self.call_after_refresh(self._on_load_complete)
 
     def _on_load_complete(self) -> None:
         """Called when file loading completes (success or failure)."""

--- a/stoei/widgets/user_overview.py
+++ b/stoei/widgets/user_overview.py
@@ -300,17 +300,18 @@ class UserOverviewTab(VerticalScroll):
         """Aggregate job data into user statistics.
 
         Args:
-            jobs: List of job tuples from squeue (JobID, Name, User, State, Time, Nodes, NodeList, [TRES]).
-                TRES is optional (8th field).
+            jobs: List of job tuples from squeue
+                (JobID, Name, User, Partition, State, Time, Nodes, NodeList, [TRES]).
+                TRES is optional (9th field).
 
         Returns:
             List of UserStats objects.
         """
         # Constants for job tuple indices
-        min_job_fields = 7  # Minimum: JobID, Name, User, State, Time, Nodes, NodeList
+        min_job_fields = 8  # Minimum: JobID, Name, User, Partition, State, Time, Nodes, NodeList
         username_index = 2
-        nodes_index = 5
-        tres_index = 7  # Optional 8th field
+        nodes_index = 6
+        tres_index = 8  # Optional 9th field
 
         def _default_user_data() -> _UserDataDict:
             """Create default user data dictionary."""

--- a/tests/integration/test_app_cluster.py
+++ b/tests/integration/test_app_cluster.py
@@ -136,8 +136,8 @@ class TestAppClusterIntegration:
         ):
             async with app.run_test(size=(80, 24)) as pilot:
                 app._all_users_jobs = [
-                    ("12345", "job1", "user1", "RUNNING", "00:05:00", "1", "node01"),
-                    ("12346", "job2", "user2", "PENDING", "00:00:00", "2", "node02"),
+                    ("12345", "job1", "user1", "gpu", "RUNNING", "00:05:00", "1", "node01"),
+                    ("12346", "job2", "user2", "cpu", "PENDING", "00:00:00", "2", "node02"),
                 ]
 
                 event = TabSwitched("users")

--- a/tests/integration/test_cluster_overview.py
+++ b/tests/integration/test_cluster_overview.py
@@ -9,6 +9,7 @@ from stoei.widgets.node_overview import NodeInfo, NodeOverviewTab
 from stoei.widgets.tabs import TabContainer
 from stoei.widgets.user_overview import UserOverviewTab, UserStats
 from textual.app import App
+from textual.widgets import Static
 
 
 class ClusterTestApp(App[None]):
@@ -189,7 +190,8 @@ class TestClusterDataIntegration:
             # Should start with loading message
             assert not sidebar._data_loaded
             # Initial content should contain loading message
-            content = str(sidebar.render())
+            content_widget = sidebar.query_one("#cluster-sidebar-content", Static)
+            content = str(content_widget.render())
             assert "Cluster Load" in content or "Loading" in content
 
     async def test_cluster_sidebar_renders_after_update(self, app: ClusterTestApp) -> None:
@@ -206,7 +208,8 @@ class TestClusterDataIntegration:
             )
             sidebar.update_stats(stats)
             assert sidebar._data_loaded
-            content = str(sidebar.render())
+            content_widget = sidebar.query_one("#cluster-sidebar-content", Static)
+            content = str(content_widget.render())
             assert "Nodes" in content
             assert "CPUs" in content
 

--- a/tests/integration/test_user_actions.py
+++ b/tests/integration/test_user_actions.py
@@ -21,7 +21,7 @@ HISTORY_JOBS: list[tuple[str, ...]] = [
 ]
 
 ALL_RUNNING_JOBS: list[tuple[str, ...]] = [
-    ("101", "train", "user1", "RUNNING", "00:10:00", "1", "node001", "cpu=4,mem=32G,gres/gpu:h100=1"),
+    ("101", "train", "user1", "gpu", "RUNNING", "00:10:00", "1", "node001", "cpu=4,mem=32G,gres/gpu:h100=1"),
 ]
 
 NODE_DATA: list[dict[str, str]] = [

--- a/tests/mocks/squeue
+++ b/tests/mocks/squeue
@@ -6,22 +6,57 @@ import random
 import sys
 
 # Constants for parsing
-MIN_JOB_FIELDS_WITH_USER = 7
-MIN_JOB_FIELDS_WITH_TRES = 8
+# All-users tuples now include Partition:
+# (JobID, Name, User, Partition, State, Time, Nodes, NodeList, [TRES])
+MIN_JOB_FIELDS_WITH_USER = 8
+MIN_JOB_FIELDS_WITH_TRES = 9
 MIN_JOB_FIELDS_WITHOUT_USER = 6
 MIN_USER_INDEX = 2
+MIN_ALL_USERS_STATE_INDEX = 4
+MIN_USER_ONLY_STATE_INDEX = 2
 MIN_RANDOM_JOBS = 2
 MAX_RANDOM_JOBS = 10
 
 # Real job data from current cluster (with user field and TRES)
 MOCK_JOBS_ALL_USERS = [
-    ("47441", "rope_pct_llama_", "afkhan", "PENDING", "0:00", "8", "(Priority)", "cpu=64,mem=512G,node=8,gres/gpu=32"),
-    ("47434", "rope_pct_llama_", "afkhan", "PENDING", "0:00", "8", "(Resources)", "cpu=64,mem=512G,node=8,gres/gpu=32"),
-    ("47587", "sam3_multigpu", "flkar", "RUNNING", "5:29:36", "1", "daisg106", "cpu=192,mem=2000G,node=1,gres/gpu=8"),
+    (
+        "47441",
+        "rope_pct_llama_",
+        "afkhan",
+        "gpu",
+        "PENDING",
+        "0:00",
+        "8",
+        "(Priority)",
+        "cpu=64,mem=512G,node=8,gres/gpu=32",
+    ),
+    (
+        "47434",
+        "rope_pct_llama_",
+        "afkhan",
+        "gpu",
+        "PENDING",
+        "0:00",
+        "8",
+        "(Resources)",
+        "cpu=64,mem=512G,node=8,gres/gpu=32",
+    ),
+    (
+        "47587",
+        "sam3_multigpu",
+        "flkar",
+        "gpu",
+        "RUNNING",
+        "5:29:36",
+        "1",
+        "daisg106",
+        "cpu=192,mem=2000G,node=1,gres/gpu=8",
+    ),
     (
         "47474_5",
         "sdvae_sit_b_2_r",
         "xichen",
+        "gpu",
         "RUNNING",
         "18:29",
         "1",
@@ -32,28 +67,51 @@ MOCK_JOBS_ALL_USERS = [
         "47475_2",
         "sdvae_sit_b_2_r",
         "xichen",
+        "gpu",
         "RUNNING",
         "32:59",
         "1",
         "daisg104",
         "cpu=192,mem=2000G,node=1,gres/gpu=8",
     ),
-    ("47429", "train", "rmaser", "RUNNING", "12:30:07", "1", "daisg116", "cpu=192,mem=2000G,node=1,gres/gpu=8"),
+    (
+        "47429",
+        "train",
+        "rmaser",
+        "gpu",
+        "RUNNING",
+        "12:30:07",
+        "1",
+        "daisg116",
+        "cpu=192,mem=2000G,node=1,gres/gpu=8",
+    ),
     (
         "46043",
         "foldmae",
         "dchen",
+        "gpu",
         "RUNNING",
         "12:58:54",
         "4",
         "daisg[111-113,115]",
         "cpu=768,mem=8000G,node=4,gres/gpu=32",
     ),
-    ("47537", "foldmae", "dchen", "PENDING", "0:00", "4", "(Priority)", "cpu=768,mem=8000G,node=4,gres/gpu=32"),
+    (
+        "47537",
+        "foldmae",
+        "dchen",
+        "gpu",
+        "PENDING",
+        "0:00",
+        "4",
+        "(Priority)",
+        "cpu=768,mem=8000G,node=4,gres/gpu=32",
+    ),
     (
         "47670",
         "17_imagenet128_",
         "bpogodzi",
+        "gpu",
         "PENDING",
         "0:00",
         "1",
@@ -64,6 +122,7 @@ MOCK_JOBS_ALL_USERS = [
         "47671",
         "17_imagenet128_",
         "bpogodzi",
+        "gpu",
         "PENDING",
         "0:00",
         "1",
@@ -74,6 +133,7 @@ MOCK_JOBS_ALL_USERS = [
         "47462_11",
         "decomposed_rep_",
         "jvanders",
+        "gpu",
         "RUNNING",
         "4:28",
         "1",
@@ -155,21 +215,41 @@ MOCK_JOBS_USER_ONLY = [
 ]
 
 
+def _normalize_all_users_job(job: tuple[str, ...]) -> tuple[str, ...]:
+    """Normalize all-users job tuples to include Partition.
+
+    Historical versions of this mock stored tuples as:
+      (JobID, Name, User, State, Time, Nodes, NodeList, [TRES])
+
+    The production app now expects:
+      (JobID, Name, User, Partition, State, Time, Nodes, NodeList, [TRES])
+    """
+    if len(job) == 7:
+        job_id, name, user, state, time, nodes, nodelist = job
+        return (job_id, name, user, "gpu", state, time, nodes, nodelist)
+    if len(job) == 8:
+        job_id, name, user, state, time, nodes, nodelist, tres = job
+        return (job_id, name, user, "gpu", state, time, nodes, nodelist, tres)
+    return job
+
+
 def print_fixed_width(jobs):
     """Print jobs in fixed width format compatible with -O."""
-    # JobID:20,Name:20,UserName:15,StateCompact:10,TimeUsed:12,NumNodes:6,NodeList:30,tres:80
+    # JobID:20,Name:20,UserName:15,Partition:15,StateCompact:10,TimeUsed:12,NumNodes:6,NodeList:30,tres:80
     for job in jobs:
+        job = _normalize_all_users_job(job)
         if len(job) < MIN_JOB_FIELDS_WITH_USER:
             continue
             
-        job_id, name, user, state, time, nodes, nodelist = job[:MIN_JOB_FIELDS_WITH_USER]
-        tres = job[7] if len(job) >= MIN_JOB_FIELDS_WITH_TRES else ""
+        job_id, name, user, partition, state, time, nodes, nodelist = job[:MIN_JOB_FIELDS_WITH_USER]
+        tres = job[8] if len(job) >= MIN_JOB_FIELDS_WITH_TRES else ""
         
         # Pad fields to match expected fixed width
         line = (
             f"{job_id:<20}"
             f"{name:<20}"
             f"{user:<15}"
+            f"{partition:<15}"
             f"{state:<10}"
             f"{time:<12}"
             f"{nodes:<6}"
@@ -198,9 +278,11 @@ def main() -> None:
     allowed_states = args.states.split(",") if args.states else None
 
     # Get job pool
+    using_all_users_jobs = False
     if is_fixed_width:
         # Fixed width mode implies full job details including TRES
-        jobs = MOCK_JOBS_ALL_USERS
+        jobs = [_normalize_all_users_job(j) for j in MOCK_JOBS_ALL_USERS]
+        using_all_users_jobs = True
     else:
         # Legacy/Simple mode
         # Determine format - check if user field is in format string
@@ -208,19 +290,23 @@ def main() -> None:
         is_all_users = args.all or (not args.user and has_user_field)
         
         if is_all_users and has_user_field:
-            jobs = MOCK_JOBS_ALL_USERS
+            jobs = [_normalize_all_users_job(j) for j in MOCK_JOBS_ALL_USERS]
+            using_all_users_jobs = True
         else:
             jobs = MOCK_JOBS_USER_ONLY
 
     # Filter by state
     if allowed_states:
-        jobs = [j for j in jobs if any(s in j[3] for s in allowed_states)] # Index 3 is STATE in both lists
+        if using_all_users_jobs:
+            jobs = [j for j in jobs if len(j) > MIN_ALL_USERS_STATE_INDEX and any(s in j[MIN_ALL_USERS_STATE_INDEX] for s in allowed_states)]
+        else:
+            jobs = [j for j in jobs if len(j) > MIN_USER_ONLY_STATE_INDEX and any(s in j[MIN_USER_ONLY_STATE_INDEX] for s in allowed_states)]
 
     # Filter by user if specified
     if args.user:
         # In MOCK_JOBS_ALL_USERS, user is at index 2
         # In MOCK_JOBS_USER_ONLY, no user field (so -u logic is just selection)
-        if jobs == MOCK_JOBS_ALL_USERS:
+        if using_all_users_jobs:
              jobs = [job for job in jobs if len(job) > MIN_USER_INDEX and job[MIN_USER_INDEX] == args.user]
         # else: user only jobs are just returned as is for that user
 
@@ -241,7 +327,7 @@ def main() -> None:
     has_tres_field = args.format and "%t" in args.format
     
     if not args.noheader:
-        if jobs == MOCK_JOBS_ALL_USERS:
+        if using_all_users_jobs:
              if has_tres_field:
                 print("     JOBID|           NAME|    USER|   STATE|      TIME|NODE|NODELIST(REASON)|TRES")
              else:
@@ -250,10 +336,10 @@ def main() -> None:
              print("     JOBID|        JOBNAME|   STATE|      TIME|   NODES|      NODELIST")
 
     for job in selected_jobs:
-        if jobs == MOCK_JOBS_ALL_USERS:
-            job_id, name, user, state, time, nodes, nodelist = job[:MIN_JOB_FIELDS_WITH_USER]
+        if using_all_users_jobs:
+            job_id, name, user, _partition, state, time, nodes, nodelist = job[:MIN_JOB_FIELDS_WITH_USER]
             if has_tres_field and len(job) >= MIN_JOB_FIELDS_WITH_TRES:
-                tres = job[7]
+                tres = job[8]
                 print(f"{job_id:>10}|{name:>15}|{user:>8}|{state:>8}|{time:>10}|{nodes:>4}|{nodelist:>12}|{tres}")
             else:
                 print(f"{job_id:>10}|{name:>15}|{user:>8}|{state:>8}|{time:>10}|{nodes:>4}|{nodelist:>12}")

--- a/tests/unit/widgets/test_user_overview.py
+++ b/tests/unit/widgets/test_user_overview.py
@@ -81,8 +81,8 @@ class TestUserOverviewTab:
     def test_aggregate_user_stats_single_user(self) -> None:
         """Test aggregating stats for a single user."""
         jobs = [
-            ("12345", "job1", "user1", "RUNNING", "1:00:00", "2", "node01,node02"),
-            ("12346", "job2", "user1", "RUNNING", "0:30:00", "1", "node03"),
+            ("12345", "job1", "user1", "gpu", "RUNNING", "1:00:00", "2", "node01,node02"),
+            ("12346", "job2", "user1", "gpu", "RUNNING", "0:30:00", "1", "node03"),
         ]
         result = UserOverviewTab.aggregate_user_stats(jobs)
         assert len(result) == 1
@@ -93,9 +93,9 @@ class TestUserOverviewTab:
     def test_aggregate_user_stats_multiple_users(self) -> None:
         """Test aggregating stats for multiple users."""
         jobs = [
-            ("12345", "job1", "user1", "RUNNING", "1:00:00", "2", "node01,node02"),
-            ("12346", "job2", "user2", "RUNNING", "0:30:00", "1", "node03"),
-            ("12347", "job3", "user1", "PENDING", "0:00:00", "1", "(null)"),
+            ("12345", "job1", "user1", "gpu", "RUNNING", "1:00:00", "2", "node01,node02"),
+            ("12346", "job2", "user2", "gpu", "RUNNING", "0:30:00", "1", "node03"),
+            ("12347", "job3", "user1", "gpu", "PENDING", "0:00:00", "1", "(null)"),
         ]
         result = UserOverviewTab.aggregate_user_stats(jobs)
         assert len(result) == 2
@@ -107,7 +107,7 @@ class TestUserOverviewTab:
     def test_aggregate_user_stats_node_range(self) -> None:
         """Test aggregating stats with node range notation."""
         jobs = [
-            ("12345", "job1", "user1", "RUNNING", "1:00:00", "4-8", "node[04-08]"),
+            ("12345", "job1", "user1", "gpu", "RUNNING", "1:00:00", "4-8", "node[04-08]"),
         ]
         result = UserOverviewTab.aggregate_user_stats(jobs)
         assert len(result) == 1
@@ -117,7 +117,7 @@ class TestUserOverviewTab:
     def test_aggregate_user_stats_invalid_node_count(self) -> None:
         """Test aggregating stats with invalid node count."""
         jobs = [
-            ("12345", "job1", "user1", "RUNNING", "1:00:00", "invalid", "node01"),
+            ("12345", "job1", "user1", "gpu", "RUNNING", "1:00:00", "invalid", "node01"),
         ]
         result = UserOverviewTab.aggregate_user_stats(jobs)
         assert len(result) == 1
@@ -136,7 +136,7 @@ class TestUserOverviewTab:
     def test_aggregate_user_stats_empty_username(self) -> None:
         """Test aggregating stats with empty username."""
         jobs = [
-            ("12345", "job1", "", "RUNNING", "1:00:00", "1", "node01"),
+            ("12345", "job1", "", "gpu", "RUNNING", "1:00:00", "1", "node01"),
         ]
         result = UserOverviewTab.aggregate_user_stats(jobs)
         # Should skip jobs with empty username
@@ -260,8 +260,18 @@ class TestUserOverviewTab:
     def test_aggregate_user_stats_with_tres_memory(self) -> None:
         """Test aggregating stats with TRES memory information."""
         jobs = [
-            ("12345", "job1", "user1", "RUNNING", "1:00:00", "2", "node01,node02", "cpu=32,mem=256G,node=2,gres/gpu=8"),
-            ("12346", "job2", "user1", "RUNNING", "0:30:00", "1", "node03", "cpu=16,mem=128G,node=1,gres/gpu=4"),
+            (
+                "12345",
+                "job1",
+                "user1",
+                "gpu",
+                "RUNNING",
+                "1:00:00",
+                "2",
+                "node01,node02",
+                "cpu=32,mem=256G,node=2,gres/gpu=8",
+            ),
+            ("12346", "job2", "user1", "gpu", "RUNNING", "0:30:00", "1", "node03", "cpu=16,mem=128G,node=1,gres/gpu=4"),
         ]
         result = UserOverviewTab.aggregate_user_stats(jobs)
         assert len(result) == 1
@@ -274,7 +284,7 @@ class TestUserOverviewTab:
     def test_aggregate_user_stats_with_tres_memory_mb(self) -> None:
         """Test aggregating stats with TRES memory in MB."""
         jobs = [
-            ("12345", "job1", "user1", "RUNNING", "1:00:00", "1", "node01", "cpu=8,mem=8192M,node=1,gres/gpu=1"),
+            ("12345", "job1", "user1", "gpu", "RUNNING", "1:00:00", "1", "node01", "cpu=8,mem=8192M,node=1,gres/gpu=1"),
         ]
         result = UserOverviewTab.aggregate_user_stats(jobs)
         assert len(result) == 1
@@ -285,9 +295,19 @@ class TestUserOverviewTab:
     def test_aggregate_user_stats_with_tres_multiple_users(self) -> None:
         """Test aggregating stats with TRES for multiple users."""
         jobs = [
-            ("12345", "job1", "user1", "RUNNING", "1:00:00", "2", "node01,node02", "cpu=32,mem=256G,node=2,gres/gpu=8"),
-            ("12346", "job2", "user2", "RUNNING", "0:30:00", "1", "node03", "cpu=16,mem=128G,node=1,gres/gpu=4"),
-            ("12347", "job3", "user1", "PENDING", "0:00:00", "1", "(null)", "cpu=8,mem=64G,node=1,gres/gpu=2"),
+            (
+                "12345",
+                "job1",
+                "user1",
+                "gpu",
+                "RUNNING",
+                "1:00:00",
+                "2",
+                "node01,node02",
+                "cpu=32,mem=256G,node=2,gres/gpu=8",
+            ),
+            ("12346", "job2", "user2", "gpu", "RUNNING", "0:30:00", "1", "node03", "cpu=16,mem=128G,node=1,gres/gpu=4"),
+            ("12347", "job3", "user1", "gpu", "PENDING", "0:00:00", "1", "(null)", "cpu=8,mem=64G,node=1,gres/gpu=2"),
         ]
         result = UserOverviewTab.aggregate_user_stats(jobs)
         assert len(result) == 2
@@ -305,7 +325,7 @@ class TestUserOverviewTab:
     def test_aggregate_user_stats_without_tres(self) -> None:
         """Test aggregating stats when TRES field is missing."""
         jobs = [
-            ("12345", "job1", "user1", "RUNNING", "1:00:00", "2", "node01,node02"),
+            ("12345", "job1", "user1", "gpu", "RUNNING", "1:00:00", "2", "node01,node02"),
         ]
         result = UserOverviewTab.aggregate_user_stats(jobs)
         assert len(result) == 1
@@ -318,7 +338,7 @@ class TestUserOverviewTab:
     def test_aggregate_user_stats_with_empty_tres(self) -> None:
         """Test aggregating stats when TRES field is empty."""
         jobs = [
-            ("12345", "job1", "user1", "RUNNING", "1:00:00", "2", "node01,node02", ""),
+            ("12345", "job1", "user1", "gpu", "RUNNING", "1:00:00", "2", "node01,node02", ""),
         ]
         result = UserOverviewTab.aggregate_user_stats(jobs)
         assert len(result) == 1
@@ -335,6 +355,7 @@ class TestUserOverviewTab:
                 "12345",
                 "job1",
                 "user1",
+                "gpu",
                 "RUNNING",
                 "1:00:00",
                 "2",
@@ -353,8 +374,18 @@ class TestUserOverviewTab:
     def test_aggregate_user_stats_mixed_tres_and_no_tres(self) -> None:
         """Test aggregating stats with mix of jobs with and without TRES."""
         jobs = [
-            ("12345", "job1", "user1", "RUNNING", "1:00:00", "2", "node01,node02", "cpu=32,mem=256G,node=2,gres/gpu=8"),
-            ("12346", "job2", "user1", "RUNNING", "0:30:00", "1", "node03"),  # No TRES
+            (
+                "12345",
+                "job1",
+                "user1",
+                "gpu",
+                "RUNNING",
+                "1:00:00",
+                "2",
+                "node01,node02",
+                "cpu=32,mem=256G,node=2,gres/gpu=8",
+            ),
+            ("12346", "job2", "user1", "gpu", "RUNNING", "0:30:00", "1", "node03"),  # No TRES
         ]
         result = UserOverviewTab.aggregate_user_stats(jobs)
         assert len(result) == 1
@@ -367,8 +398,28 @@ class TestUserOverviewTab:
     def test_aggregate_user_stats_with_gpu_types(self) -> None:
         """Test aggregating stats with GPU type information."""
         jobs = [
-            ("12345", "job1", "user1", "RUNNING", "1:00:00", "1", "node01", "cpu=32,mem=256G,node=1,gres/gpu:h200=8"),
-            ("12346", "job2", "user1", "RUNNING", "0:30:00", "1", "node02", "cpu=16,mem=128G,node=1,gres/gpu:h200=4"),
+            (
+                "12345",
+                "job1",
+                "user1",
+                "gpu",
+                "RUNNING",
+                "1:00:00",
+                "1",
+                "node01",
+                "cpu=32,mem=256G,node=1,gres/gpu:h200=8",
+            ),
+            (
+                "12346",
+                "job2",
+                "user1",
+                "gpu",
+                "RUNNING",
+                "0:30:00",
+                "1",
+                "node02",
+                "cpu=16,mem=128G,node=1,gres/gpu:h200=4",
+            ),
         ]
         result = UserOverviewTab.aggregate_user_stats(jobs)
         assert len(result) == 1
@@ -378,8 +429,28 @@ class TestUserOverviewTab:
     def test_aggregate_user_stats_with_multiple_gpu_types(self) -> None:
         """Test aggregating stats with multiple GPU types."""
         jobs = [
-            ("12345", "job1", "user1", "RUNNING", "1:00:00", "1", "node01", "cpu=32,mem=256G,node=1,gres/gpu:h200=8"),
-            ("12346", "job2", "user1", "RUNNING", "0:30:00", "1", "node02", "cpu=16,mem=128G,node=1,gres/gpu:a100=4"),
+            (
+                "12345",
+                "job1",
+                "user1",
+                "gpu",
+                "RUNNING",
+                "1:00:00",
+                "1",
+                "node01",
+                "cpu=32,mem=256G,node=1,gres/gpu:h200=8",
+            ),
+            (
+                "12346",
+                "job2",
+                "user1",
+                "gpu",
+                "RUNNING",
+                "0:30:00",
+                "1",
+                "node02",
+                "cpu=16,mem=128G,node=1,gres/gpu:a100=4",
+            ),
         ]
         result = UserOverviewTab.aggregate_user_stats(jobs)
         assert len(result) == 1
@@ -395,6 +466,7 @@ class TestUserOverviewTab:
                 "12345",
                 "job1",
                 "user1",
+                "gpu",
                 "RUNNING",
                 "1:00:00",
                 "1",


### PR DESCRIPTION
- Add partition to the all-users squeue fetch and parse it from fixed-width output.
- Aggregate pending resources per partition (CPUs, memory, GPUs incl. typed GPUs) and render Pending Queue as a partition breakdown.
- Make the cluster sidebar reliably scrollable with a visible scrollbar.