### PR TITLE
feat: redesign priority tab with intuitive interface

### DIFF
--- a/docs/plans/2026-02-25-feat-intuitive-priority-interface.md
+++ b/docs/plans/2026-02-25-feat-intuitive-priority-interface.md
@@ -1,0 +1,248 @@
+---
+title: "Intuitive Priority Interface"
+type: enhancement
+date: 2026-02-25
+---
+
+# Intuitive Priority Interface
+
+## Overview
+
+Redesign the Priority tab to make it immediately obvious where the current user stands in scheduling priority, how other users compare, and how their account (institute) is consuming its allocated resources. The current Priority tab shows raw sshare/sprio numbers in three flat tables with no visual differentiation, no current-user highlighting, and no relative context.
+
+## Problem Statement
+
+The current Priority tab (`stoei/widgets/priority_overview.py`) has three sub-tabs -- Users, Accounts, Jobs -- that display raw SLURM data as plain text tables. Users must:
+
+1. **Visually scan** a potentially large list to find their own username (no highlighting)
+2. **Interpret raw numbers** like `FairShare: 0.450000` with no context for what that means relative to peers
+3. **Switch between sub-tabs** to cross-reference their user priority with their account priority
+4. **Understand SLURM internals** (FairShare, EffectvUsage, NormShares) without any guidance
+
+The result is a data dump, not a usable interface for answering the questions users actually have: "Will my job run soon?" and "Is my group using its fair share?"
+
+## Proposed Solution
+
+Restructure the Priority tab into four sub-tabs with a focus-first-then-explore information hierarchy:
+
+| Sub-tab | Key | Purpose |
+|---------|-----|---------|
+| **My Priority** | `m` | Current user's priority summary + their pending jobs |
+| **All Users** | `u` | All users ranked by FairShare with current user highlighted |
+| **Accounts** | `a` | Account/institute usage comparison with user's account highlighted |
+| **Jobs** | `j` | All pending jobs priority factors (existing, enhanced) |
+
+### Key Enhancements
+
+1. **Current user row highlighting** -- bold + accent color markup on the user's row in all tables
+2. **Rank column** -- "3/42" showing position in the sorted list (pre-computed, stable across re-sorts)
+3. **FairShare color-coding** -- green (>= 0.5, under-served), yellow (>= 0.2, fair), red (< 0.2, over-served) using existing `_FAIR_SHARE_SUCCESS_THRESHOLD` / `_FAIR_SHARE_WARNING_THRESHOLD` from `stoei/slurm/formatters.py:471-472`
+4. **Status column** -- human-readable label: "Under-served" / "Fair" / "Over-served"
+5. **"My Priority" summary sub-tab** -- composite view showing the user's rank, FairShare, account context, and their pending jobs in one place
+
+## Technical Approach
+
+### Phase 1: Color-Coding and User Highlighting
+
+Enhance existing tables without structural changes. Low risk, high value.
+
+**Files to modify:**
+
+- `stoei/widgets/priority_overview.py` -- Add `current_username` parameter, apply Rich markup to FairShare cells and current user rows
+- `stoei/app.py` -- Pass `self._current_username` when building priority cache and calling update methods
+
+**Changes to `priority_overview.py`:**
+
+```python
+# Add current_username to __init__
+def __init__(self, *, current_username: str = "", ...):
+    self._current_username = current_username
+
+# Add Status column to USER_PRIORITY_COLUMNS
+ColumnConfig(name="Status", key="status", sortable=True, filterable=True, width=12)
+
+# Color-code FairShare and highlight current user row in update_user_priorities()
+def update_user_priorities(self, priorities: list[UserPriority]) -> None:
+    colors = get_theme_colors(self.app)
+    for p in sorted_priorities:
+        is_me = p.username == self._current_username
+        fs_color = _fair_share_color(p.fair_share, colors)
+        status = _fair_share_status(p.fair_share)
+        if is_me:
+            style = f"bold {colors.accent}"
+            row = (f"[{style}]>> {p.username}[/{style}]", ...)
+        else:
+            row = (p.username, ..., f"[{fs_color}]{p.fair_share}[/{fs_color}]", status)
+```
+
+**Changes to `app.py`:**
+
+```python
+# Pass current_username when creating PriorityOverviewTab
+PriorityOverviewTab(current_username=self._current_username, id="priority-overview")
+
+# Pass current_username in cache computation
+def _compute_priority_overview_cache(self):
+    # Add rank computation (position in FairShare-sorted list)
+    for i, p in enumerate(sorted_user_priorities, 1):
+        p.rank = f"{i}/{len(sorted_user_priorities)}"
+```
+
+### Phase 2: Rank Column
+
+Add a pre-computed rank column to Users and Accounts tables.
+
+**Files to modify:**
+
+- `stoei/widgets/priority_overview.py` -- Add `Rank` column config, add `rank` field to `UserPriority` and `AccountPriority` dataclasses
+- `stoei/app.py` -- Compute ranks in `_compute_priority_overview_cache()`
+
+**Rank computation:**
+
+```python
+# Dense ranking (ties share the same rank)
+def _compute_ranks(values: list[float]) -> list[str]:
+    total = len(values)
+    ranks: list[str] = []
+    prev_val = None
+    rank = 0
+    for val in values:  # already sorted descending
+        if val != prev_val:
+            rank += 1
+        ranks.append(f"{rank}/{total}")
+        prev_val = val
+    return ranks
+```
+
+**Column additions:**
+
+```python
+USER_PRIORITY_COLUMNS = [
+    ColumnConfig(name="Rank", key="rank", sortable=False, filterable=False, width=8),
+    ColumnConfig(name="User", ...),
+    # ... existing columns ...
+    ColumnConfig(name="Status", key="status", sortable=True, filterable=True, width=12),
+]
+```
+
+### Phase 3: "My Priority" Sub-tab
+
+Add a new default sub-tab showing the current user's priority summary.
+
+**Files to modify:**
+
+- `stoei/widgets/priority_overview.py` -- Add new sub-tab container, new `PrioritySubtabName` literal, compose changes
+- `stoei/styles/app.tcss` -- Styling for summary panel (if needed)
+
+**"My Priority" sub-tab content (composite Static + FilterableDataTable):**
+
+```
+┌─ Your Priority ──────────────────────────────────────────────┐
+│  FairShare: 0.650000   Status: Under-served   Rank: 5/42    │
+│  Account: physics      Account Rank: 2/8                     │
+│  Shares: 50 (12.5% of cluster)                               │
+└──────────────────────────────────────────────────────────────┘
+
+Your Pending Jobs (3)
+┌──────────┬──────────┬──────────┬──────────┬──────────┬──────┐
+│ JobID    │ Priority │ Age      │ FairShare│ Partition│ QOS  │
+├──────────┼──────────┼──────────┼──────────┼──────────┼──────┤
+│ 47441    │ 1500     │ 100      │ 800      │ 300      │ 100  │
+│ 47434    │ 1400     │ 80       │ 750      │ 270      │ 100  │
+│ 47420    │ 1200     │ 50       │ 700      │ 250      │ 100  │
+└──────────┴──────────┴──────────┴──────────┴──────────┴──────┘
+```
+
+**Implementation approach:**
+
+- Top section: `Static` widget with Rich Panel showing summary, updated via `update()` on each refresh
+- Bottom section: `FilterableDataTable` filtered to only the current user's pending jobs from sprio
+- If user not found in sshare data: show `[dim]No fair-share data found for 'username'. This may occur if you have not submitted jobs recently.[/dim]`
+
+**Sub-tab layout after Phase 3:**
+
+```python
+PrioritySubtabName = Literal["mine", "users", "accounts", "jobs"]
+
+BINDINGS = [
+    Binding("m", "switch_subtab_mine", "My Priority", show=False),
+    Binding("u", "switch_subtab_users", "All Users", show=False),
+    Binding("a", "switch_subtab_accounts", "Accounts", show=False),
+    Binding("j", "switch_subtab_jobs", "Jobs", show=False),
+]
+```
+
+Default active sub-tab changes from `"users"` to `"mine"`.
+
+### Phase 4 (Optional): Weight Info and Account Hierarchy
+
+Lower priority enhancements that can be done in a follow-up.
+
+- **`sprio -w` weights**: Fetch once on initial load, display as dim header text on the Jobs sub-tab (e.g., `[dim]Weights: Age=1000 FairShare=10000 JobSize=0 Partition=5000 QOS=5000[/dim]`)
+- **Account parent column**: Add `Parent` column to Accounts table by fetching account hierarchy from `sacctmgr show account format=Account,ParentName -P --noheader` (one-time fetch)
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+- [ ] Priority tab default sub-tab is "My Priority" showing current user's summary
+- [ ] Current user's row is highlighted (bold + accent color) in All Users and Jobs tables
+- [ ] FairShare values are color-coded: green (>= 0.5), yellow (>= 0.2), red (< 0.2)
+- [ ] "Status" column shows human-readable label in Users and Accounts tables
+- [ ] "Rank" column shows dense-ranked position (e.g., "3/42") in Users and Accounts tables
+- [ ] Rank values are stable (pre-computed by FairShare sort order, not affected by user's current sort)
+- [ ] "My Priority" sub-tab shows user's FairShare, status, rank, account info, and pending jobs
+- [ ] "My Priority" shows graceful empty state when user is not in sshare data
+- [ ] Sub-tab keybindings: `m` (My Priority), `u` (All Users), `a` (Accounts), `j` (Jobs)
+- [ ] Current user's account row is highlighted in Accounts table
+- [ ] All existing Enter/click-to-detail interactions still work (UserInfoScreen, AccountInfoScreen)
+
+### Non-Functional Requirements
+
+- [ ] No new SLURM commands in Phase 1-3 (reuses existing sshare + sprio data)
+- [ ] Test suite passes and stays under 20 seconds
+- [ ] Rank computation happens in background worker thread (in `_compute_priority_overview_cache`)
+- [ ] Color-coding uses existing `ThemeColors` infrastructure from `stoei/colors.py`
+- [ ] FairShare thresholds use existing constants from `stoei/slurm/formatters.py`
+
+## Dependencies
+
+- Uses existing `get_fair_share_priority()` and `get_pending_job_priority()` commands -- no new SLURM calls needed for Phases 1-3
+- Uses existing `_FAIR_SHARE_SUCCESS_THRESHOLD` (0.5) and `_FAIR_SHARE_WARNING_THRESHOLD` (0.2) from `stoei/slurm/formatters.py:471-472`
+- Uses existing `ThemeColors.pct_color()` pattern from `stoei/colors.py`
+- Uses existing `self._current_username` from `stoei/app.py:183`
+- Uses existing `FilterableDataTable` for all table views
+- Phase 4 would require new `sacctmgr` and `sprio -w` commands
+
+## Files to Create/Modify
+
+| File | Action | Phase | Description |
+|------|--------|-------|-------------|
+| `stoei/widgets/priority_overview.py` | Modify | 1-3 | Add current_username, color-coding, rank, Status column, "My Priority" sub-tab |
+| `stoei/app.py` | Modify | 1-3 | Pass current_username to widget, compute ranks in cache, update sub-tab handling |
+| `stoei/slurm/formatters.py` | Modify | 1 | Extract `_fair_share_color()` and `_fair_share_status()` as reusable functions |
+| `tests/unit/widgets/test_priority_overview.py` | Modify | 1-3 | Update for new columns, sub-tab names, highlighting, rank |
+| `tests/unit/slurm/test_priority.py` | Modify | 2 | Test rank computation |
+| `tests/mocks/sprio` | No change | - | Existing mock data is sufficient |
+| `tests/mocks/sshare` | No change | - | Existing mock data is sufficient |
+
+## Design Decisions
+
+**Why not a separate dashboard screen?** The Priority tab already exists with sub-tabs. Adding "My Priority" as the default sub-tab keeps navigation consistent (still tab 4) and avoids a new screen that users must discover.
+
+**Why dense ranking for ties?** If two users have the same FairShare, they should show the same rank. Dense ranking (1, 2, 2, 3) is more intuitive than competition ranking (1, 2, 2, 4) for "where do I stand?" questions.
+
+**Why keep the Jobs sub-tab?** The "My Priority" sub-tab will show only the current user's pending jobs. The Jobs sub-tab shows ALL pending jobs across all users, which sysadmins need for fairshare validation.
+
+**Why use existing FairShare thresholds (0.5/0.2) instead of the 1.0 boundary?** The sshare FairShare value is already normalized to [0.0, 1.0] on most SLURM clusters. The existing thresholds in `formatters.py` are already validated in the UserInfoScreen and AccountInfoScreen, so reusing them ensures consistency.
+
+## References
+
+- Current widget: `stoei/widgets/priority_overview.py`
+- FairShare thresholds: `stoei/slurm/formatters.py:471-472`
+- App priority orchestration: `stoei/app.py:817` (`_fetch_priority`), `stoei/app.py:1568` (`_compute_priority_overview_cache`)
+- Current username: `stoei/app.py:183` (`self._current_username`)
+- Theme colors: `stoei/colors.py` (`ThemeColors`, `get_theme_colors`, `pct_color`)
+- SLURM sshare docs: https://slurm.schedmd.com/sshare.html
+- SLURM sprio docs: https://slurm.schedmd.com/sprio.html
+- SLURM Fair Tree algorithm: https://slurm.schedmd.com/fair_tree.html

--- a/stoei/app.py
+++ b/stoei/app.py
@@ -261,7 +261,7 @@ class SlurmMonitor(App[None]):
 
                 # Priority tab
                 with Container(id="tab-priority-content", classes="tab-content"):
-                    yield PriorityOverviewTab(id="priority-overview")
+                    yield PriorityOverviewTab(current_username=self._current_username, id="priority-overview")
 
                 # Logs tab
                 with Container(id="tab-logs-content", classes="tab-content"):
@@ -1761,9 +1761,17 @@ class SlurmMonitor(App[None]):
             self.call_later(self._update_priority_overview)
         try:
             priority_tab = self.query_one("#priority-overview", PriorityOverviewTab)
-            priority_table = priority_tab.query_one("#user_priority_table", DataTable)
+            # Focus the table in the currently active sub-tab
+            subtab_table_ids = {
+                "mine": "my_job_priority_table",
+                "users": "user_priority_table",
+                "accounts": "account_priority_table",
+                "jobs": "job_priority_table",
+            }
+            table_id = subtab_table_ids.get(priority_tab.active_subtab, "my_job_priority_table")
+            priority_table = priority_tab.query_one(f"#{table_id}", DataTable)
             priority_table.focus()
-            logger.debug("Focused priority table for arrow key navigation")
+            logger.debug(f"Focused priority table {table_id} for arrow key navigation")
         except Exception as exc:
             logger.debug(f"Failed to focus priority table: {exc}")
 

--- a/stoei/slurm/formatters.py
+++ b/stoei/slurm/formatters.py
@@ -557,6 +557,45 @@ def _format_fair_share_value(
     return f"[{color}]{display}[/{color}]"
 
 
+def fair_share_color(fair_share: str, colors: ThemeColors) -> str:
+    """Get the appropriate color for a fair-share value.
+
+    Args:
+        fair_share: Fair-share factor as string.
+        colors: Theme colors.
+
+    Returns:
+        Hex color string based on the fair-share thresholds.
+    """
+    val = _safe_float(fair_share, default=float("nan"))
+    if math.isnan(val):
+        return colors.foreground
+    if val >= _FAIR_SHARE_SUCCESS_THRESHOLD:
+        return colors.success
+    if val >= _FAIR_SHARE_WARNING_THRESHOLD:
+        return colors.warning
+    return colors.error
+
+
+def fair_share_status(fair_share: str) -> str:
+    """Get a human-readable status label for a fair-share value.
+
+    Args:
+        fair_share: Fair-share factor as string.
+
+    Returns:
+        Status label: "Under-served", "Fair", or "Over-served".
+    """
+    val = _safe_float(fair_share, default=float("nan"))
+    if math.isnan(val):
+        return ""
+    if val >= _FAIR_SHARE_SUCCESS_THRESHOLD:
+        return "Under-served"
+    if val >= _FAIR_SHARE_WARNING_THRESHOLD:
+        return "Fair"
+    return "Over-served"
+
+
 def _format_energy_wh(wh: float) -> str:
     """Format an energy value in Wh as Wh/kWh/MWh.
 

--- a/stoei/widgets/priority_overview.py
+++ b/stoei/widgets/priority_overview.py
@@ -1,6 +1,6 @@
 """Priority overview tab widget with sub-tabs for user, account, and job priority views."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import ClassVar, Literal
 
 from textual.app import ComposeResult
@@ -9,12 +9,39 @@ from textual.containers import Container, Horizontal, VerticalScroll
 from textual.message import Message
 from textual.widgets import Static
 
+from stoei.colors import ThemeColors, get_theme_colors
 from stoei.logger import get_logger
 from stoei.settings import load_settings
+from stoei.slurm.formatters import fair_share_color, fair_share_status
 from stoei.slurm.parser import parse_sprio_output, parse_sshare_output
 from stoei.widgets.filterable_table import ColumnConfig, FilterableDataTable
 
 logger = get_logger(__name__)
+
+
+def compute_dense_ranks(values: list[float]) -> list[str]:
+    """Compute dense ranks for a descending-sorted list of values.
+
+    Tied values share the same rank (e.g., 1, 2, 2, 3).
+
+    Args:
+        values: List of float values, already sorted descending.
+
+    Returns:
+        List of rank strings like "1/42", "2/42", etc.
+    """
+    total = len(values)
+    if total == 0:
+        return []
+    ranks: list[str] = []
+    prev_val: float | None = None
+    rank = 0
+    for val in values:
+        if val != prev_val:
+            rank += 1
+        ranks.append(f"{rank}/{total}")
+        prev_val = val
+    return ranks
 
 
 @dataclass
@@ -29,6 +56,7 @@ class UserPriority:
     norm_usage: str
     effective_usage: str
     fair_share: str
+    rank: str = field(default="")
 
 
 @dataclass
@@ -42,6 +70,7 @@ class AccountPriority:
     norm_usage: str
     effective_usage: str
     fair_share: str
+    rank: str = field(default="")
 
 
 @dataclass
@@ -73,7 +102,113 @@ class PrioritySubtabSwitched(Message):
 
 
 # Type alias for subtab names
-PrioritySubtabName = Literal["users", "accounts", "jobs"]
+PrioritySubtabName = Literal["mine", "users", "accounts", "jobs"]
+
+# Container IDs for each sub-tab
+_SUBTAB_CONTAINER_IDS: list[str] = [
+    "priority-subtab-mine",
+    "priority-subtab-users",
+    "priority-subtab-accounts",
+    "priority-subtab-jobs",
+]
+
+
+def _style_cell(value: str, style: str) -> str:
+    """Wrap a cell value in Rich markup style.
+
+    Args:
+        value: The cell text.
+        style: The Rich style string (e.g., "bold #a3be8c").
+
+    Returns:
+        Styled Rich markup string.
+    """
+    return f"[{style}]{value}[/{style}]"
+
+
+def _format_fs_cell(fair_share: str, colors: ThemeColors) -> str:
+    """Format a FairShare cell with color coding.
+
+    Args:
+        fair_share: FairShare value as string.
+        colors: Theme colors.
+
+    Returns:
+        Rich markup string with appropriate color.
+    """
+    color = fair_share_color(fair_share, colors)
+    return f"[bold {color}]{fair_share}[/bold {color}]"
+
+
+def _format_status_cell(fair_share: str, colors: ThemeColors) -> str:
+    """Format a Status cell with color coding.
+
+    Args:
+        fair_share: FairShare value as string.
+        colors: Theme colors.
+
+    Returns:
+        Rich markup string with status label and color.
+    """
+    status = fair_share_status(fair_share)
+    if not status:
+        return ""
+    color = fair_share_color(fair_share, colors)
+    return f"[{color}]{status}[/{color}]"
+
+
+def _build_my_priority_summary(
+    current_username: str,
+    user_priorities: list[UserPriority],
+    account_priorities: list[AccountPriority],
+    job_priorities: list[JobPriority],
+    colors: ThemeColors,
+) -> str:
+    """Build the Rich markup for the 'My Priority' summary panel.
+
+    Args:
+        current_username: The current user's username.
+        user_priorities: Sorted user priority list.
+        account_priorities: Sorted account priority list.
+        job_priorities: All pending job priorities.
+        colors: Theme colors.
+
+    Returns:
+        Rich markup string for the summary Static widget.
+    """
+    my_priority = next((p for p in user_priorities if p.username == current_username), None)
+    if my_priority is None:
+        return (
+            f"[{colors.text_muted}]No fair-share data found for '{current_username}'. "
+            f"This may occur if you have not submitted jobs recently "
+            f"or if fair-share is not configured on this cluster.[/{colors.text_muted}]"
+        )
+
+    # User's FairShare with color
+    fs_color = fair_share_color(my_priority.fair_share, colors)
+    status = fair_share_status(my_priority.fair_share)
+    rank = my_priority.rank or "?"
+
+    # Find account info
+    my_account_priority = next((a for a in account_priorities if a.account == my_priority.account), None)
+    account_rank = my_account_priority.rank if my_account_priority else "?"
+
+    # Count my pending jobs
+    my_jobs = [j for j in job_priorities if j.user == current_username]
+    pending_count = len(my_jobs)
+
+    lines = [
+        "[bold]Your Priority[/bold]",
+        "",
+        f"  FairShare: [bold {fs_color}]{my_priority.fair_share}[/bold {fs_color}]"
+        f"   Status: [{fs_color}]{status}[/{fs_color}]"
+        f"   Rank: [bold]{rank}[/bold]",
+        f"  Account: [bold]{my_priority.account}[/bold]   Account Rank: [bold]{account_rank}[/bold]",
+        f"  Shares: {my_priority.raw_shares} ({my_priority.norm_shares} of cluster)",
+        "",
+        f"  Pending Jobs: [bold]{pending_count}[/bold]",
+    ]
+    return "\n".join(lines)
 
 
 class PriorityOverviewTab(VerticalScroll):
@@ -104,16 +239,26 @@ class PriorityOverviewTab(VerticalScroll):
         margin-bottom: 1;
         color: $text-muted;
     }
+
+    #my-priority-summary {
+        margin-bottom: 1;
+    }
+
+    #my-priority-jobs-header {
+        margin-bottom: 0;
+    }
     """
 
     BINDINGS: ClassVar[list[Binding]] = [
-        Binding("u", "switch_subtab_users", "Users", show=False),
+        Binding("m", "switch_subtab_mine", "My Priority", show=False),
+        Binding("u", "switch_subtab_users", "All Users", show=False),
         Binding("a", "switch_subtab_accounts", "Accounts", show=False),
         Binding("j", "switch_subtab_jobs", "Jobs", show=False),
     ]
 
     # Column configs for each priority table
     USER_PRIORITY_COLUMNS: ClassVar[list[ColumnConfig]] = [
+        ColumnConfig(name="Rank", key="rank", sortable=False, filterable=False, width=8),
         ColumnConfig(name="User", key="user", sortable=True, filterable=True, width=15),
         ColumnConfig(name="Account", key="account", sortable=True, filterable=True, width=15),
         ColumnConfig(name="RawShares", key="raw_shares", sortable=True, filterable=True, width=12),
@@ -121,15 +266,28 @@ class PriorityOverviewTab(VerticalScroll):
         ColumnConfig(name="RawUsage", key="raw_usage", sortable=True, filterable=True, width=12),
         ColumnConfig(name="EffectvUsage", key="effective_usage", sortable=True, filterable=True, width=12),
         ColumnConfig(name="FairShare", key="fair_share", sortable=True, filterable=True, width=10),
+        ColumnConfig(name="Status", key="status", sortable=True, filterable=True, width=12),
     ]
 
     ACCOUNT_PRIORITY_COLUMNS: ClassVar[list[ColumnConfig]] = [
+        ColumnConfig(name="Rank", key="rank", sortable=False, filterable=False, width=8),
         ColumnConfig(name="Account", key="account", sortable=True, filterable=True, width=20),
         ColumnConfig(name="RawShares", key="raw_shares", sortable=True, filterable=True, width=12),
         ColumnConfig(name="NormShares", key="norm_shares", sortable=True, filterable=True, width=12),
         ColumnConfig(name="RawUsage", key="raw_usage", sortable=True, filterable=True, width=14),
         ColumnConfig(name="EffectvUsage", key="effective_usage", sortable=True, filterable=True, width=12),
         ColumnConfig(name="FairShare", key="fair_share", sortable=True, filterable=True, width=10),
+        ColumnConfig(name="Status", key="status", sortable=True, filterable=True, width=12),
+    ]
+
+    MY_JOB_PRIORITY_COLUMNS: ClassVar[list[ColumnConfig]] = [
+        ColumnConfig(name="JobID", key="job_id", sortable=True, filterable=True, width=12),
+        ColumnConfig(name="Priority", key="priority", sortable=True, filterable=True, width=10),
+        ColumnConfig(name="Age", key="age", sortable=True, filterable=True, width=10),
+        ColumnConfig(name="FairShare", key="fair_share", sortable=True, filterable=True, width=10),
+        ColumnConfig(name="JobSize", key="job_size", sortable=True, filterable=True, width=10),
+        ColumnConfig(name="Partition", key="partition", sortable=True, filterable=True, width=10),
+        ColumnConfig(name="QOS", key="qos", sortable=True, filterable=True, width=10),
     ]
 
     JOB_PRIORITY_COLUMNS: ClassVar[list[ColumnConfig]] = [
@@ -147,6 +305,7 @@ class PriorityOverviewTab(VerticalScroll):
     def __init__(
         self,
         *,
+        current_username: str = "",
         name: str | None = None,
         id: str | None = None,
         classes: str | None = None,
@@ -155,16 +314,18 @@ class PriorityOverviewTab(VerticalScroll):
         """Initialize the PriorityOverviewTab widget.
 
         Args:
+            current_username: The current user's username for highlighting.
             name: The name of the widget.
             id: The ID of the widget in the DOM.
             classes: The CSS classes for the widget.
             disabled: Whether the widget is disabled.
         """
         super().__init__(name=name, id=id, classes=classes, disabled=disabled)
+        self._current_username = current_username
         self.user_priorities: list[UserPriority] = []
         self.account_priorities: list[AccountPriority] = []
         self.job_priorities: list[JobPriority] = []
-        self._active_subtab: PrioritySubtabName = "users"
+        self._active_subtab: PrioritySubtabName = "mine"
         self._settings = load_settings()
 
     def compose(self) -> ComposeResult:
@@ -173,14 +334,32 @@ class PriorityOverviewTab(VerticalScroll):
         with Horizontal(id="priority-subtab-header"):
             yield Static(
                 "[bold]Priority[/bold]  "
-                "[bold reverse] u [/bold reverse]Users  "
+                "[bold reverse] m [/bold reverse]My Priority  "
+                "[dim]u[/dim] All Users  "
                 "[dim]a[/dim] Accounts  "
                 "[dim]j[/dim] Jobs",
                 id="priority-subtab-header-text",
             )
 
-        # Users priority sub-tab (default visible)
-        with Container(id="priority-subtab-users", classes="priority-subtab-content"):
+        # My Priority sub-tab (default visible)
+        with Container(id="priority-subtab-mine", classes="priority-subtab-content"):
+            yield Static(
+                "[dim]Loading priority data...[/dim]",
+                id="my-priority-summary",
+            )
+            yield Static(
+                "[bold]Your Pending Jobs[/bold]",
+                id="my-priority-jobs-header",
+            )
+            yield FilterableDataTable(
+                columns=self.MY_JOB_PRIORITY_COLUMNS,
+                keybind_mode=self._settings.keybind_mode,
+                table_id="my_job_priority_table",
+                id="my-job-priority-filterable-table",
+            )
+
+        # All Users priority sub-tab (hidden by default)
+        with Container(id="priority-subtab-users", classes="priority-subtab-content priority-subtab-hidden"):
             yield Static(
                 "[dim]Fair-share priority per user (higher FairShare = higher scheduling priority)[/dim]",
                 id="priority-info-text",
@@ -220,7 +399,6 @@ class PriorityOverviewTab(VerticalScroll):
 
     def on_mount(self) -> None:
         """Initialize the data tables."""
-        # If we already have data, update the tables
         if self.user_priorities:
             self.update_user_priorities(self.user_priorities)
         if self.account_priorities:
@@ -237,7 +415,7 @@ class PriorityOverviewTab(VerticalScroll):
         """Switch to a different sub-tab.
 
         Args:
-            subtab: Name of the sub-tab to switch to ('users', 'accounts', or 'jobs').
+            subtab: Name of the sub-tab to switch to.
         """
         if subtab == self._active_subtab:
             return
@@ -248,7 +426,7 @@ class PriorityOverviewTab(VerticalScroll):
         self._update_subtab_header(subtab)
 
         # Hide all subtab containers
-        for container_id in ["priority-subtab-users", "priority-subtab-accounts", "priority-subtab-jobs"]:
+        for container_id in _SUBTAB_CONTAINER_IDS:
             try:
                 container = self.query_one(f"#{container_id}", Container)
                 container.add_class("priority-subtab-hidden")
@@ -262,7 +440,8 @@ class PriorityOverviewTab(VerticalScroll):
             active_container.remove_class("priority-subtab-hidden")
 
             # Focus the appropriate filterable table
-            filterable_ids = {
+            filterable_ids: dict[PrioritySubtabName, str] = {
+                "mine": "my-job-priority-filterable-table",
                 "users": "user-priority-filterable-table",
                 "accounts": "account-priority-filterable-table",
                 "jobs": "job-priority-filterable-table",
@@ -286,19 +465,26 @@ class PriorityOverviewTab(VerticalScroll):
         try:
             header = self.query_one("#priority-subtab-header-text", Static)
 
-            # Build header with active tab highlighted
-            users_style = "[bold reverse] u [/bold reverse]Users" if active == "users" else "[dim]u[/dim] Users"
-            accounts_style = (
-                "[bold reverse] a [/bold reverse]Accounts" if active == "accounts" else "[dim]a[/dim] Accounts"
-            )
-            jobs_style = "[bold reverse] j [/bold reverse]Jobs" if active == "jobs" else "[dim]j[/dim] Jobs"
+            def _tab_style(key: str, label: str, tab_name: PrioritySubtabName) -> str:
+                if active == tab_name:
+                    return f"[bold reverse] {key} [/bold reverse]{label}"
+                return f"[dim]{key}[/dim] {label}"
 
-            header.update(f"[bold]Priority[/bold]  {users_style}  {accounts_style}  {jobs_style}")
+            mine = _tab_style("m", "My Priority", "mine")
+            users = _tab_style("u", "All Users", "users")
+            accounts = _tab_style("a", "Accounts", "accounts")
+            jobs = _tab_style("j", "Jobs", "jobs")
+
+            header.update(f"[bold]Priority[/bold]  {mine}  {users}  {accounts}  {jobs}")
         except Exception as exc:
             logger.debug(f"Failed to update subtab header: {exc}")
 
+    def action_switch_subtab_mine(self) -> None:
+        """Switch to the My Priority sub-tab."""
+        self.switch_subtab("mine")
+
     def action_switch_subtab_users(self) -> None:
-        """Switch to the Users sub-tab."""
+        """Switch to the All Users sub-tab."""
         self.switch_subtab("users")
 
     def action_switch_subtab_accounts(self) -> None:
@@ -309,6 +495,73 @@ class PriorityOverviewTab(VerticalScroll):
         """Switch to the Jobs sub-tab."""
         self.switch_subtab("jobs")
 
+    def _get_current_user_account(self) -> str:
+        """Get the current user's account from the user priorities.
+
+        Returns:
+            The account name, or empty string if not found.
+        """
+        my_priority = next((p for p in self.user_priorities if p.username == self._current_username), None)
+        return my_priority.account if my_priority else ""
+
+    def update_my_priority_summary(self) -> None:
+        """Update the 'My Priority' summary panel."""
+        try:
+            summary = self.query_one("#my-priority-summary", Static)
+        except Exception:
+            return
+
+        colors = get_theme_colors(self.app)
+        markup = _build_my_priority_summary(
+            self._current_username,
+            self.user_priorities,
+            self.account_priorities,
+            self.job_priorities,
+            colors,
+        )
+        summary.update(markup)
+
+    def update_my_job_priorities(self) -> None:
+        """Update the 'My Priority' pending jobs table."""
+        try:
+            filterable = self.query_one("#my-job-priority-filterable-table", FilterableDataTable)
+        except Exception:
+            return
+
+        my_jobs = [j for j in self.job_priorities if j.user == self._current_username]
+
+        # Sort by priority descending
+        def sort_key(p: JobPriority) -> float:
+            try:
+                return float(p.priority)
+            except ValueError:
+                return 0.0
+
+        my_jobs.sort(key=sort_key, reverse=True)
+
+        rows: list[tuple[str, ...]] = []
+        for p in my_jobs:
+            rows.append(
+                (
+                    p.job_id,
+                    p.priority,
+                    p.age,
+                    p.fair_share,
+                    p.job_size,
+                    p.partition,
+                    p.qos,
+                )
+            )
+
+        filterable.set_data(rows)
+
+        # Update header with count
+        try:
+            header = self.query_one("#my-priority-jobs-header", Static)
+            header.update(f"[bold]Your Pending Jobs ({len(my_jobs)})[/bold]")
+        except Exception as exc:
+            logger.debug(f"Failed to update my-priority jobs header: {exc}")
+
     def update_user_priorities(self, priorities: list[UserPriority]) -> None:
         """Update the user priority data table.
 
@@ -318,7 +571,6 @@ class PriorityOverviewTab(VerticalScroll):
         try:
             filterable = self.query_one("#user-priority-filterable-table", FilterableDataTable)
         except Exception:
-            # Table might not be mounted yet, store for later
             self.user_priorities = priorities
             return
 
@@ -330,24 +582,56 @@ class PriorityOverviewTab(VerticalScroll):
                 return 0.0
 
         sorted_priorities = sorted(priorities, key=sort_key, reverse=True)
+
+        # Compute dense ranks
+        fs_values = [sort_key(p) for p in sorted_priorities]
+        ranks = compute_dense_ranks(fs_values)
+        for p, rank in zip(sorted_priorities, ranks, strict=True):
+            p.rank = rank
+
         self.user_priorities = sorted_priorities
 
-        # Build row data
+        # Build row data with color-coding and highlighting
+        colors = get_theme_colors(self.app)
         rows: list[tuple[str, ...]] = []
         for p in sorted_priorities:
-            rows.append(
-                (
-                    p.username,
-                    p.account,
-                    p.raw_shares,
-                    p.norm_shares,
-                    p.raw_usage,
-                    p.effective_usage,
-                    p.fair_share,
+            is_me = p.username == self._current_username
+            if is_me:
+                # Highlight current user's row
+                style = f"bold {colors.accent}"
+                rows.append(
+                    (
+                        _style_cell(p.rank, style),
+                        _style_cell(f">> {p.username}", style),
+                        _style_cell(p.account, style),
+                        _style_cell(p.raw_shares, style),
+                        _style_cell(p.norm_shares, style),
+                        _style_cell(p.raw_usage, style),
+                        _style_cell(p.effective_usage, style),
+                        _format_fs_cell(p.fair_share, colors),
+                        _format_status_cell(p.fair_share, colors),
+                    )
                 )
-            )
+            else:
+                rows.append(
+                    (
+                        p.rank,
+                        p.username,
+                        p.account,
+                        p.raw_shares,
+                        p.norm_shares,
+                        p.raw_usage,
+                        p.effective_usage,
+                        _format_fs_cell(p.fair_share, colors),
+                        _format_status_cell(p.fair_share, colors),
+                    )
+                )
 
         filterable.set_data(rows)
+
+        # Also update my priority summary and jobs if mounted
+        self.update_my_priority_summary()
+        self.update_my_job_priorities()
 
     def update_account_priorities(self, priorities: list[AccountPriority]) -> None:
         """Update the account priority data table.
@@ -358,7 +642,6 @@ class PriorityOverviewTab(VerticalScroll):
         try:
             filterable = self.query_one("#account-priority-filterable-table", FilterableDataTable)
         except Exception:
-            # Table might not be mounted yet, store for later
             self.account_priorities = priorities
             return
 
@@ -370,23 +653,53 @@ class PriorityOverviewTab(VerticalScroll):
                 return 0.0
 
         sorted_priorities = sorted(priorities, key=sort_key, reverse=True)
+
+        # Compute dense ranks
+        fs_values = [sort_key(p) for p in sorted_priorities]
+        ranks = compute_dense_ranks(fs_values)
+        for p, rank in zip(sorted_priorities, ranks, strict=True):
+            p.rank = rank
+
         self.account_priorities = sorted_priorities
 
-        # Build row data
+        # Build row data with color-coding and highlighting
+        colors = get_theme_colors(self.app)
+        my_account = self._get_current_user_account()
         rows: list[tuple[str, ...]] = []
         for p in sorted_priorities:
-            rows.append(
-                (
-                    p.account,
-                    p.raw_shares,
-                    p.norm_shares,
-                    p.raw_usage,
-                    p.effective_usage,
-                    p.fair_share,
+            is_mine = p.account == my_account and my_account != ""
+            if is_mine:
+                style = f"bold {colors.accent}"
+                rows.append(
+                    (
+                        _style_cell(p.rank, style),
+                        _style_cell(p.account, style),
+                        _style_cell(p.raw_shares, style),
+                        _style_cell(p.norm_shares, style),
+                        _style_cell(p.raw_usage, style),
+                        _style_cell(p.effective_usage, style),
+                        _format_fs_cell(p.fair_share, colors),
+                        _format_status_cell(p.fair_share, colors),
+                    )
                 )
-            )
+            else:
+                rows.append(
+                    (
+                        p.rank,
+                        p.account,
+                        p.raw_shares,
+                        p.norm_shares,
+                        p.raw_usage,
+                        p.effective_usage,
+                        _format_fs_cell(p.fair_share, colors),
+                        _format_status_cell(p.fair_share, colors),
+                    )
+                )
 
         filterable.set_data(rows)
+
+        # Also update my priority summary
+        self.update_my_priority_summary()
 
     def update_job_priorities(self, priorities: list[JobPriority]) -> None:
         """Update the job priority data table.
@@ -397,7 +710,6 @@ class PriorityOverviewTab(VerticalScroll):
         try:
             filterable = self.query_one("#job-priority-filterable-table", FilterableDataTable)
         except Exception:
-            # Table might not be mounted yet, store for later
             self.job_priorities = priorities
             return
 
@@ -411,24 +723,45 @@ class PriorityOverviewTab(VerticalScroll):
         sorted_priorities = sorted(priorities, key=sort_key, reverse=True)
         self.job_priorities = sorted_priorities
 
-        # Build row data
+        # Build row data with current user highlighting
+        colors = get_theme_colors(self.app)
         rows: list[tuple[str, ...]] = []
         for p in sorted_priorities:
-            rows.append(
-                (
-                    p.job_id,
-                    p.user,
-                    p.account,
-                    p.priority,
-                    p.age,
-                    p.fair_share,
-                    p.job_size,
-                    p.partition,
-                    p.qos,
+            is_me = p.user == self._current_username
+            if is_me:
+                style = f"bold {colors.accent}"
+                rows.append(
+                    (
+                        _style_cell(p.job_id, style),
+                        _style_cell(p.user, style),
+                        _style_cell(p.account, style),
+                        _style_cell(p.priority, style),
+                        _style_cell(p.age, style),
+                        _style_cell(p.fair_share, style),
+                        _style_cell(p.job_size, style),
+                        _style_cell(p.partition, style),
+                        _style_cell(p.qos, style),
+                    )
                 )
-            )
+            else:
+                rows.append(
+                    (
+                        p.job_id,
+                        p.user,
+                        p.account,
+                        p.priority,
+                        p.age,
+                        p.fair_share,
+                        p.job_size,
+                        p.partition,
+                        p.qos,
+                    )
+                )
 
         filterable.set_data(rows)
+
+        # Also update my pending jobs
+        self.update_my_job_priorities()
 
     def update_from_sshare_data(self, entries: list[tuple[str, ...]]) -> None:
         """Update user and account priorities from raw sshare data.
@@ -438,7 +771,6 @@ class PriorityOverviewTab(VerticalScroll):
         """
         user_data, account_data = parse_sshare_output(entries)
 
-        # Convert to dataclasses
         user_priorities = [
             UserPriority(
                 username=d["User"],
@@ -477,7 +809,6 @@ class PriorityOverviewTab(VerticalScroll):
         """
         job_data = parse_sprio_output(entries)
 
-        # Convert to dataclasses
         job_priorities = [
             JobPriority(
                 job_id=d["JobID"],

--- a/tests/unit/widgets/test_priority_overview.py
+++ b/tests/unit/widgets/test_priority_overview.py
@@ -1,12 +1,18 @@
 """Unit tests for the PriorityOverviewTab widget."""
 
 import pytest
+from stoei.colors import FALLBACK_COLORS, ThemeColors
+from stoei.slurm.formatters import fair_share_color, fair_share_status
+from stoei.widgets.filterable_table import FilterableDataTable
 from stoei.widgets.priority_overview import (
     AccountPriority,
     JobPriority,
     PriorityOverviewTab,
     UserPriority,
+    compute_dense_ranks,
 )
+from textual.app import App
+from textual.widgets import Static
 
 
 class TestUserPriority:
@@ -32,6 +38,22 @@ class TestUserPriority:
         assert priority.norm_usage == "0.075"
         assert priority.effective_usage == "0.15"
         assert priority.fair_share == "0.85"
+        assert priority.rank == ""
+
+    def test_user_priority_with_rank(self) -> None:
+        """Test creating a UserPriority object with rank."""
+        priority = UserPriority(
+            username="testuser",
+            account="physics",
+            raw_shares="100",
+            norm_shares="0.125",
+            raw_usage="50000",
+            norm_usage="0.075",
+            effective_usage="0.15",
+            fair_share="0.85",
+            rank="1/5",
+        )
+        assert priority.rank == "1/5"
 
 
 class TestAccountPriority:
@@ -55,6 +77,7 @@ class TestAccountPriority:
         assert priority.norm_usage == "0.15"
         assert priority.effective_usage == "0.15"
         assert priority.fair_share == "0.85"
+        assert priority.rank == ""
 
 
 class TestJobPriority:
@@ -84,6 +107,74 @@ class TestJobPriority:
         assert priority.qos == "100"
 
 
+class TestComputeDenseRanks:
+    """Tests for dense rank computation."""
+
+    def test_empty_list(self) -> None:
+        """Test ranking an empty list."""
+        assert compute_dense_ranks([]) == []
+
+    def test_single_element(self) -> None:
+        """Test ranking a single element."""
+        assert compute_dense_ranks([1.0]) == ["1/1"]
+
+    def test_all_unique(self) -> None:
+        """Test ranking with all unique values (already sorted desc)."""
+        assert compute_dense_ranks([0.9, 0.7, 0.5, 0.3]) == ["1/4", "2/4", "3/4", "4/4"]
+
+    def test_ties(self) -> None:
+        """Test dense ranking with tied values."""
+        assert compute_dense_ranks([0.9, 0.7, 0.7, 0.3]) == ["1/4", "2/4", "2/4", "3/4"]
+
+    def test_all_same(self) -> None:
+        """Test ranking when all values are the same."""
+        assert compute_dense_ranks([0.5, 0.5, 0.5]) == ["1/3", "1/3", "1/3"]
+
+
+class TestFairShareHelpers:
+    """Tests for fair share color and status helper functions."""
+
+    def test_fair_share_status_under_served(self) -> None:
+        """Test status for under-served (high FairShare)."""
+        assert fair_share_status("0.85") == "Under-served"
+        assert fair_share_status("0.50") == "Under-served"
+
+    def test_fair_share_status_fair(self) -> None:
+        """Test status for fair (medium FairShare)."""
+        assert fair_share_status("0.35") == "Fair"
+        assert fair_share_status("0.20") == "Fair"
+
+    def test_fair_share_status_over_served(self) -> None:
+        """Test status for over-served (low FairShare)."""
+        assert fair_share_status("0.10") == "Over-served"
+        assert fair_share_status("0.00") == "Over-served"
+
+    def test_fair_share_status_invalid(self) -> None:
+        """Test status for non-numeric value."""
+        assert fair_share_status("N/A") == ""
+
+    def test_fair_share_color_returns_string(self) -> None:
+        """Test that fair_share_color returns a color string."""
+        colors = ThemeColors(
+            success=FALLBACK_COLORS["success"],
+            warning=FALLBACK_COLORS["warning"],
+            error=FALLBACK_COLORS["error"],
+            primary=FALLBACK_COLORS["primary"],
+            accent=FALLBACK_COLORS["accent"],
+            secondary=FALLBACK_COLORS["secondary"],
+            foreground=FALLBACK_COLORS["foreground"],
+            text_muted=FALLBACK_COLORS["text_muted"],
+            background=FALLBACK_COLORS["background"],
+            surface=FALLBACK_COLORS["surface"],
+            panel=FALLBACK_COLORS["panel"],
+            border=FALLBACK_COLORS["border"],
+        )
+        assert fair_share_color("0.85", colors) == colors.success
+        assert fair_share_color("0.35", colors) == colors.warning
+        assert fair_share_color("0.10", colors) == colors.error
+        assert fair_share_color("invalid", colors) == colors.foreground
+
+
 class TestPriorityOverviewTab:
     """Tests for the PriorityOverviewTab widget."""
 
@@ -99,12 +190,21 @@ class TestPriorityOverviewTab:
         assert priority_tab.job_priorities == []
 
     def test_initial_active_subtab(self, priority_tab: PriorityOverviewTab) -> None:
-        """Test that initial active subtab is users."""
-        assert priority_tab.active_subtab == "users"
+        """Test that initial active subtab is 'mine'."""
+        assert priority_tab.active_subtab == "mine"
+
+    def test_current_username_default(self) -> None:
+        """Test that current_username defaults to empty string."""
+        tab = PriorityOverviewTab(id="test")
+        assert tab._current_username == ""
+
+    def test_current_username_set(self) -> None:
+        """Test that current_username can be set via constructor."""
+        tab = PriorityOverviewTab(current_username="testuser", id="test")
+        assert tab._current_username == "testuser"
 
     async def test_update_user_priorities(self) -> None:
         """Test updating user priorities - requires mounted widget."""
-        from textual.app import App
 
         class PriorityTestApp(App[None]):
             def compose(self):
@@ -139,10 +239,12 @@ class TestPriorityOverviewTab:
             # Should be sorted by fair share descending
             assert len(priority_tab.user_priorities) == 2
             assert priority_tab.user_priorities[0].username == "user1"  # 0.85 > 0.70
+            # Should have ranks computed
+            assert priority_tab.user_priorities[0].rank == "1/2"
+            assert priority_tab.user_priorities[1].rank == "2/2"
 
     async def test_update_account_priorities(self) -> None:
         """Test updating account priorities - requires mounted widget."""
-        from textual.app import App
 
         class PriorityTestApp(App[None]):
             def compose(self):
@@ -175,10 +277,12 @@ class TestPriorityOverviewTab:
             # Should be sorted by fair share descending
             assert len(priority_tab.account_priorities) == 2
             assert priority_tab.account_priorities[0].account == "physics"
+            # Should have ranks computed
+            assert priority_tab.account_priorities[0].rank == "1/2"
+            assert priority_tab.account_priorities[1].rank == "2/2"
 
     async def test_update_job_priorities(self) -> None:
         """Test updating job priorities - requires mounted widget."""
-        from textual.app import App
 
         class PriorityTestApp(App[None]):
             def compose(self):
@@ -218,7 +322,6 @@ class TestPriorityOverviewTab:
 
     async def test_switch_subtab(self) -> None:
         """Test switching between subtabs."""
-        from textual.app import App
 
         class PriorityTestApp(App[None]):
             def compose(self):
@@ -228,6 +331,9 @@ class TestPriorityOverviewTab:
         async with app.run_test(size=(80, 24)):
             priority_tab = app.query_one("#priority-overview", PriorityOverviewTab)
 
+            assert priority_tab.active_subtab == "mine"
+
+            priority_tab.switch_subtab("users")
             assert priority_tab.active_subtab == "users"
 
             priority_tab.switch_subtab("accounts")
@@ -236,12 +342,11 @@ class TestPriorityOverviewTab:
             priority_tab.switch_subtab("jobs")
             assert priority_tab.active_subtab == "jobs"
 
-            priority_tab.switch_subtab("users")
-            assert priority_tab.active_subtab == "users"
+            priority_tab.switch_subtab("mine")
+            assert priority_tab.active_subtab == "mine"
 
     async def test_update_from_sshare_data(self) -> None:
         """Test updating from raw sshare data."""
-        from textual.app import App
 
         class PriorityTestApp(App[None]):
             def compose(self):
@@ -265,7 +370,6 @@ class TestPriorityOverviewTab:
 
     async def test_update_from_sprio_data(self) -> None:
         """Test updating from raw sprio data."""
-        from textual.app import App
 
         class PriorityTestApp(App[None]):
             def compose(self):
@@ -286,13 +390,75 @@ class TestPriorityOverviewTab:
             # Should be sorted by priority descending
             assert priority_tab.job_priorities[0].job_id == "12345"
 
+    async def test_my_priority_summary_no_data(self) -> None:
+        """Test 'My Priority' summary when user is not found."""
+
+        class PriorityTestApp(App[None]):
+            def compose(self):
+                yield PriorityOverviewTab(current_username="unknown_user", id="priority-overview")
+
+        app = PriorityTestApp()
+        async with app.run_test(size=(80, 24)):
+            priority_tab = app.query_one("#priority-overview", PriorityOverviewTab)
+            # Update with data that doesn't include the current user
+            priorities = [
+                UserPriority("user1", "physics", "100", "0.125", "50000", "0.075", "0.15", "0.85"),
+            ]
+            priority_tab.update_user_priorities(priorities)
+            # Summary should show "not found" message
+            summary = app.query_one("#my-priority-summary", Static)
+            assert "No fair-share data found" in summary.content
+
+    async def test_my_priority_summary_with_data(self) -> None:
+        """Test 'My Priority' summary when user has data."""
+
+        class PriorityTestApp(App[None]):
+            def compose(self):
+                yield PriorityOverviewTab(current_username="user1", id="priority-overview")
+
+        app = PriorityTestApp()
+        async with app.run_test(size=(80, 24)):
+            priority_tab = app.query_one("#priority-overview", PriorityOverviewTab)
+            priorities = [
+                UserPriority("user1", "physics", "100", "0.125", "50000", "0.075", "0.15", "0.85"),
+                UserPriority("user2", "chemistry", "50", "0.0625", "100000", "0.15", "0.30", "0.70"),
+            ]
+            priority_tab.update_user_priorities(priorities)
+            summary = app.query_one("#my-priority-summary", Static)
+            content = summary.content
+            assert "Your Priority" in content
+            assert "physics" in content
+
+    async def test_user_highlighting(self) -> None:
+        """Test that current user's row is highlighted with >> prefix."""
+
+        class PriorityTestApp(App[None]):
+            def compose(self):
+                yield PriorityOverviewTab(current_username="user1", id="priority-overview")
+
+        app = PriorityTestApp()
+        async with app.run_test(size=(80, 24)):
+            priority_tab = app.query_one("#priority-overview", PriorityOverviewTab)
+            priorities = [
+                UserPriority("user1", "physics", "100", "0.125", "50000", "0.075", "0.15", "0.85"),
+                UserPriority("user2", "chemistry", "50", "0.0625", "100000", "0.15", "0.30", "0.70"),
+            ]
+            priority_tab.update_user_priorities(priorities)
+
+            # Switch to users subtab and check the data
+            priority_tab.switch_subtab("users")
+            filterable = priority_tab.query_one("#user-priority-filterable-table", FilterableDataTable)
+            table = filterable.query_one("#user_priority_table")
+            # The first row (user1) should have >> prefix in the User column
+            row_data = table.get_row_at(0)
+            assert ">> user1" in str(row_data[1])
+
 
 class TestPriorityOverviewSorting:
     """Tests for priority sorting behavior."""
 
     async def test_user_priorities_sorted_by_fair_share(self) -> None:
         """Test that user priorities are sorted by fair share descending."""
-        from textual.app import App
 
         class PriorityTestApp(App[None]):
             def compose(self):
@@ -313,9 +479,13 @@ class TestPriorityOverviewSorting:
             assert priority_tab.user_priorities[1].username == "user3"
             assert priority_tab.user_priorities[2].username == "user1"
 
+            # Ranks should be computed
+            assert priority_tab.user_priorities[0].rank == "1/3"
+            assert priority_tab.user_priorities[1].rank == "2/3"
+            assert priority_tab.user_priorities[2].rank == "3/3"
+
     async def test_job_priorities_sorted_by_priority(self) -> None:
         """Test that job priorities are sorted by priority descending."""
-        from textual.app import App
 
         class PriorityTestApp(App[None]):
             def compose(self):


### PR DESCRIPTION
## Summary

- Restructures the Priority tab from 3 sub-tabs (Users, Accounts, Jobs) into 4 sub-tabs (**My Priority**, All Users, Accounts, Jobs) with a focus-first-then-explore hierarchy
- Adds a **"My Priority" default sub-tab** showing the current user's FairShare, rank, account context, and pending jobs in one composite view
- Adds **Rank column** with dense ranking (e.g., "3/42") to Users and Accounts tables, pre-computed from FairShare sort order
- Adds **Status column** with human-readable labels (Under-served / Fair / Over-served) based on existing FairShare thresholds
- **Color-codes FairShare values** using existing thresholds (green >= 0.5, yellow >= 0.2, red < 0.2)
- **Highlights current user's row** in All Users and Jobs tables with bold accent color and `>>` prefix
- **Highlights current user's account** in the Accounts table
- Adds `fair_share_color()` and `fair_share_status()` reusable helpers to `stoei/slurm/formatters.py`
- Expands test suite from 13 to 29 tests covering ranks, colors, highlighting, summary panel, and new sub-tab structure