### PR TITLE
feat: show running job and array counts in My Usage banner

### DIFF
--- a/docs/plans/2026-03-02-feat-job-array-count-overview-plan.md
+++ b/docs/plans/2026-03-02-feat-job-array-count-overview-plan.md
@@ -1,0 +1,138 @@
+---
+title: "feat: Show running job and array counts in My Usage banner"
+type: feat
+date: 2026-03-02
+---
+
+# feat: Show running job and array counts in My Usage banner
+
+## Problem Statement
+
+The "My Usage" banner shows resource consumption (CPUs, RAM, GPUs, Nodes) but gives no indication of **how many jobs are running** or **how many are job arrays**. A user with 100 running tasks from a single array cannot tell this from the current display.
+
+**Current banner:**
+```
+My Usage: 48 CPUs | 192.0 GB | 4 GPUs (4x H100) | 3 Nodes
+```
+
+**Desired banner:**
+```
+My Usage: 48 CPUs | 192.0 GB | 4 GPUs (4x H100) | 3 Nodes | 100 tasks (1 array, 0 jobs)
+```
+
+## Proposed Solution
+
+Add a job-count segment to the banner using data already available in `UserStats`. Classify each running job at aggregation time by inspecting the JobID field:
+
+- `"47441"` — no `_` → plain regular job (counts toward `plain_job_count`)
+- `"47474_5"` — `_` present, no `[` → running array task (base ID `"47474"` added to `array_base_ids`)
+- `"47700_[0-49]"` — contains `_[` → pending array (ignored in running aggregation)
+
+## Technical Approach
+
+### New fields on `UserStats` (`stoei/widgets/user_overview.py:38`)
+
+```python
+array_count: int = 0        # distinct running arrays (unique base job IDs)
+plain_job_count: int = 0    # non-array running jobs
+```
+
+`job_count` keeps its current meaning (total running task rows).
+
+### New accumulator keys in `_UserDataDict` (`user_overview.py:51`)
+
+```python
+array_base_ids: set[str]    # replace total_nodes analogy: a set, not int
+plain_job_count: int
+```
+
+### Update `_process_job_for_user()` (`user_overview.py:525`)
+
+Classify `job[0]` (the JobID field):
+
+```python
+# stoei/widgets/user_overview.py (inside _process_job_for_user)
+job_id = job[0].strip()
+if "_[" in job_id:
+    pass  # pending array leaking in — ignore for running counts
+elif "_" in job_id:
+    user_data["array_base_ids"].add(job_id.split("_")[0])
+else:
+    user_data["plain_job_count"] += 1
+```
+
+### Update `_convert_to_user_stats()` (`user_overview.py:583`)
+
+```python
+array_count=len(data["array_base_ids"]),
+plain_job_count=data["plain_job_count"],
+```
+
+### Update `_update_my_usage_summary()` (`app.py:1707`)
+
+Append a new segment after Nodes. Use singular/plural:
+
+```python
+# stoei/app.py (inside _update_my_usage_summary)
+x = my_stats.job_count
+y = my_stats.array_count
+z = my_stats.plain_job_count
+task_word = "task" if x == 1 else "tasks"
+array_word = "array" if y == 1 else "arrays"
+job_word = "job" if z == 1 else "jobs"
+parts.append(f"{x} {task_word} ({y} {array_word}, {z} {job_word})")
+```
+
+## Acceptance Criteria
+
+- [ ] A user with N tasks in a single array sees `N tasks (1 array, 0 jobs)`
+- [ ] A user with tasks spread across 2 arrays and 3 regular jobs sees `X tasks (2 arrays, 3 jobs)`
+- [ ] A user with only regular jobs sees `N tasks (0 arrays, N jobs)`
+- [ ] Singular forms used correctly: `1 task`, `1 array`, `1 job`
+- [ ] Pending-only user: banner falls through to `"My Usage: No running jobs"` — unchanged
+- [ ] `job_count` semantics unchanged (existing Users tab column unaffected)
+- [ ] `_update_my_usage_summary()` test verifies banner string includes the new segment
+- [ ] `uv run ruff check .`, `uv run ty check stoei/`, `uv run pytest` all pass
+
+## Files to Change
+
+| File | Change |
+|---|---|
+| `stoei/widgets/user_overview.py` | `UserStats` (2 new fields), `_UserDataDict` (2 new keys), `_process_job_for_user()` (classify job ID), `_convert_to_user_stats()` (populate new fields), `_default_user_data()` (init new keys) |
+| `stoei/app.py` | `_update_my_usage_summary()` — append task-count segment to `parts` |
+| `tests/unit/widgets/test_user_overview.py` | New tests for aggregation with array/regular/mixed jobs |
+| `tests/unit/test_app.py` | New test for `_update_my_usage_summary` banner string with array counts |
+
+## Test Scenarios
+
+### `test_user_overview.py` — aggregation classification
+
+| Scenario | Jobs | Expected `array_count` | Expected `plain_job_count` |
+|---|---|---|---|
+| All plain jobs | `"47441"`, `"47442"`, `"47443"` | `0` | `3` |
+| 5 tasks from 1 array | `"12345_0"` … `"12345_4"` | `1` | `0` |
+| Tasks from 2 distinct arrays | `"12345_0"`, `"12345_1"`, `"99999_0"` | `2` | `0` |
+| Mixed | `"12345_0"`, `"99999_0"`, `"47441"`, `"47442"`, `"47443"` | `2` | `3` |
+| Single array task | `"12345_0"` | `1` | `0` |
+| Pending array leaking in | `"12345_[0-49]"` | `0` | `0` |
+| Empty job ID | `""` | `0` | `1` (no `_`, treated as plain) |
+
+### `test_app.py` — banner string
+
+| Scenario | `array_count` | `plain_job_count` | `job_count` | Expected segment |
+|---|---|---|---|---|
+| Mixed | `2` | `3` | `15` | `"15 tasks (2 arrays, 3 jobs)"` |
+| All array | `1` | `0` | `10` | `"10 tasks (1 array, 0 jobs)"` |
+| Singular | `1` | `1` | `2` | `"2 tasks (1 array, 1 job)"` |
+| Single task | `0` | `1` | `1` | `"1 task (0 arrays, 1 job)"` |
+
+## References
+
+- `stoei/widgets/user_overview.py:38` — `UserStats` dataclass
+- `stoei/widgets/user_overview.py:51` — `_UserDataDict`
+- `stoei/widgets/user_overview.py:525` — `_process_job_for_user()`
+- `stoei/widgets/user_overview.py:583` — `_convert_to_user_stats()`
+- `stoei/widgets/user_overview.py:610` — `aggregate_user_stats()`
+- `stoei/app.py:1707` — `_update_my_usage_summary()`
+- `stoei/app.py:256` — `my-usage-summary` Static widget
+- `stoei/slurm/array_parser.py` — existing `normalize_array_job_id()`, `parse_array_size()`

--- a/stoei/app.py
+++ b/stoei/app.py
@@ -1731,6 +1731,14 @@ class SlurmMonitor(App[None]):
             parts.append(gpu_label)
         parts.append(f"{my_stats.total_nodes} Nodes")
 
+        x = my_stats.job_count
+        y = my_stats.array_count
+        z = my_stats.plain_job_count
+        task_word = "task" if x == 1 else "tasks"
+        array_word = "array" if y == 1 else "arrays"
+        job_word = "job" if z == 1 else "jobs"
+        parts.append(f"{x} {task_word} ({y} {array_word}, {z} {job_word})")
+
         summary.update(f"My Usage: {' | '.join(parts)}")
 
     def _apply_priority_overview_from_cache(self) -> None:

--- a/stoei/widgets/user_overview.py
+++ b/stoei/widgets/user_overview.py
@@ -46,6 +46,8 @@ class UserStats:
     total_nodes: int
     gpu_types: str = ""
     node_names: str = ""
+    array_count: int = 0
+    plain_job_count: int = 0
 
 
 class _UserDataDict(TypedDict):
@@ -57,6 +59,8 @@ class _UserDataDict(TypedDict):
     total_gpus: int
     gpu_types: dict[str, int]
     node_names: set[str]
+    array_base_ids: set[str]
+    plain_job_count: int
 
 
 @dataclass
@@ -541,6 +545,15 @@ class UserOverviewTab(VerticalScroll):
         """
         user_data["job_count"] += 1
 
+        # Classify job as array task or plain regular job
+        job_id = job[0].strip() if job else ""
+        if "_[" in job_id:
+            pass  # pending array leaking in — ignore for running counts
+        elif "_" in job_id:
+            user_data["array_base_ids"].add(job_id.split("_")[0])
+        else:
+            user_data["plain_job_count"] += 1
+
         # Parse nodes (format: "4" or "4-8") — used as CPU fallback only
         nodes_str = job[nodes_index].strip() if len(job) > nodes_index else "0"
         node_count = UserOverviewTab._parse_node_count(nodes_str)
@@ -602,6 +615,8 @@ class UserOverviewTab(VerticalScroll):
                     total_nodes=len(data["node_names"]),
                     gpu_types=gpu_types_str,
                     node_names=node_names_str,
+                    array_count=len(data["array_base_ids"]),
+                    plain_job_count=data["plain_job_count"],
                 )
             )
         return user_stats
@@ -634,6 +649,8 @@ class UserOverviewTab(VerticalScroll):
                 "total_gpus": 0,
                 "gpu_types": defaultdict(int),
                 "node_names": set(),
+                "array_base_ids": set(),
+                "plain_job_count": 0,
             }
 
         user_data: dict[str, _UserDataDict] = defaultdict(_default_user_data)

--- a/tests/unit/slurm/test_commands.py
+++ b/tests/unit/slurm/test_commands.py
@@ -1,8 +1,10 @@
 """Tests for SLURM command execution with mock executables."""
 
+from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 from stoei.slurm.commands import _parse_fixed_width_squeue_line, _validate_username
 
 
@@ -467,6 +469,12 @@ class TestRunSacctForJob:
 class TestCommandErrorPaths:
     """Tests for error handling in commands."""
 
+    @pytest.fixture(autouse=True)
+    def no_retry_sleep(self) -> Generator[None, None, None]:
+        """Eliminate retry backoff sleeps so error-path tests run instantly."""
+        with patch("stoei.slurm.commands.time.sleep"):
+            yield
+
     def test_get_running_jobs_handles_missing_squeue(self) -> None:
         from stoei.slurm.commands import get_running_jobs
 
@@ -630,6 +638,12 @@ class TestCommandErrorPaths:
 
 class TestGetWaitTimeJobHistory:
     """Tests for get_wait_time_job_history function."""
+
+    @pytest.fixture(autouse=True)
+    def no_retry_sleep(self) -> Generator[None, None, None]:
+        """Eliminate retry backoff sleeps so error-path tests run instantly."""
+        with patch("stoei.slurm.commands.time.sleep"):
+            yield
 
     def test_returns_jobs_list(self, mock_slurm_path: Path) -> None:
         from stoei.slurm.commands import get_wait_time_job_history

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1,5 +1,6 @@
 """Tests for the main SlurmMonitor app."""
 
+from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -199,6 +200,12 @@ class TestRefreshDataAsync:
     def reset_job_cache(self) -> None:
         """Reset JobCache singleton before each test."""
         JobCache.reset()
+
+    @pytest.fixture(autouse=True)
+    def mock_energy_fetch(self) -> Generator[None, None, None]:
+        """Prevent _fetch_energy from calling real SLURM commands regardless of user settings."""
+        with patch("stoei.app.get_energy_job_history", return_value=([], None)):
+            yield
 
     def test_refresh_data_is_sync_function(self) -> None:
         """Verify that _refresh_data_async is a regular sync function (not async).

--- a/tests/unit/widgets/test_user_overview.py
+++ b/tests/unit/widgets/test_user_overview.py
@@ -193,6 +193,81 @@ class TestUserOverviewTab:
         # Should skip jobs with empty username
         assert len(result) == 0
 
+    def test_aggregate_job_classification_all_plain(self) -> None:
+        """All plain (non-array) jobs yield array_count=0, plain_job_count=N."""
+        jobs = [
+            ("47441", "job1", "user1", "gpu", "RUNNING", "1:00:00", "1", "node01"),
+            ("47442", "job2", "user1", "gpu", "RUNNING", "0:30:00", "1", "node02"),
+            ("47443", "job3", "user1", "gpu", "RUNNING", "0:15:00", "1", "node03"),
+        ]
+        result = UserOverviewTab.aggregate_user_stats(jobs)
+        assert len(result) == 1
+        assert result[0].array_count == 0
+        assert result[0].plain_job_count == 3
+
+    def test_aggregate_job_classification_all_array_one_group(self) -> None:
+        """Multiple tasks from a single array count as 1 distinct array."""
+        jobs = [
+            ("12345_0", "job1", "user1", "gpu", "RUNNING", "1:00:00", "1", "node01"),
+            ("12345_1", "job1", "user1", "gpu", "RUNNING", "0:30:00", "1", "node02"),
+            ("12345_2", "job1", "user1", "gpu", "RUNNING", "0:15:00", "1", "node03"),
+            ("12345_3", "job1", "user1", "gpu", "RUNNING", "0:10:00", "1", "node04"),
+            ("12345_4", "job1", "user1", "gpu", "RUNNING", "0:05:00", "1", "node05"),
+        ]
+        result = UserOverviewTab.aggregate_user_stats(jobs)
+        assert len(result) == 1
+        assert result[0].array_count == 1
+        assert result[0].plain_job_count == 0
+        assert result[0].job_count == 5
+
+    def test_aggregate_job_classification_two_distinct_arrays(self) -> None:
+        """Tasks from two different arrays count as 2 distinct arrays."""
+        jobs = [
+            ("12345_0", "job1", "user1", "gpu", "RUNNING", "1:00:00", "1", "node01"),
+            ("12345_1", "job1", "user1", "gpu", "RUNNING", "0:30:00", "1", "node02"),
+            ("99999_0", "job2", "user1", "gpu", "RUNNING", "0:15:00", "1", "node03"),
+        ]
+        result = UserOverviewTab.aggregate_user_stats(jobs)
+        assert len(result) == 1
+        assert result[0].array_count == 2
+        assert result[0].plain_job_count == 0
+
+    def test_aggregate_job_classification_mixed(self) -> None:
+        """Mix of array tasks and plain jobs is classified correctly."""
+        jobs = [
+            ("12345_0", "job1", "user1", "gpu", "RUNNING", "1:00:00", "1", "node01"),
+            ("99999_0", "job2", "user1", "gpu", "RUNNING", "0:30:00", "1", "node02"),
+            ("47441", "job3", "user1", "gpu", "RUNNING", "0:15:00", "1", "node03"),
+            ("47442", "job4", "user1", "gpu", "RUNNING", "0:10:00", "1", "node04"),
+            ("47443", "job5", "user1", "gpu", "RUNNING", "0:05:00", "1", "node05"),
+        ]
+        result = UserOverviewTab.aggregate_user_stats(jobs)
+        assert len(result) == 1
+        assert result[0].array_count == 2
+        assert result[0].plain_job_count == 3
+        assert result[0].job_count == 5
+
+    def test_aggregate_job_classification_pending_array_ignored(self) -> None:
+        """Pending array job IDs (containing '_[') do not count as arrays or plain jobs."""
+        jobs = [
+            ("12345_[0-49]", "job1", "user1", "gpu", "PENDING", "0:00:00", "50", "(Resources)"),
+        ]
+        result = UserOverviewTab.aggregate_user_stats(jobs)
+        assert len(result) == 1
+        assert result[0].array_count == 0
+        assert result[0].plain_job_count == 0
+        assert result[0].job_count == 1  # job_count still increments
+
+    def test_aggregate_job_classification_single_array_task(self) -> None:
+        """Single running array task: array_count=1, plain_job_count=0."""
+        jobs = [
+            ("12345_0", "job1", "user1", "gpu", "RUNNING", "1:00:00", "1", "node01"),
+        ]
+        result = UserOverviewTab.aggregate_user_stats(jobs)
+        assert len(result) == 1
+        assert result[0].array_count == 1
+        assert result[0].plain_job_count == 0
+
     async def test_update_users_sorts_by_cpus(self) -> None:
         """Test that users are sorted by CPU usage (descending)."""
         from textual.app import App
@@ -1170,3 +1245,90 @@ class TestUpdateMyUsageSummary:
                 app._update_my_usage_summary([])
                 summary = app.query_one("#my-usage-summary", Static)
                 assert "No running jobs" in summary.content
+
+    async def test_my_usage_shows_task_count_mixed(self) -> None:
+        """Banner shows task count with array and plain job breakdown."""
+        from unittest.mock import patch
+
+        from stoei.app import SlurmMonitor
+
+        app = SlurmMonitor()
+        app._current_username = "alice"
+        with (
+            patch("stoei.app.check_slurm_available", return_value=(True, None)),
+            patch.object(app, "_start_refresh_worker"),
+        ):
+            async with app.run_test(size=(80, 24)):
+                users = [
+                    UserStats(
+                        username="alice",
+                        job_count=15,
+                        total_cpus=48,
+                        total_memory_gb=192.0,
+                        total_gpus=0,
+                        total_nodes=3,
+                        array_count=2,
+                        plain_job_count=3,
+                    ),
+                ]
+                app._update_my_usage_summary(users)
+                text = app.query_one("#my-usage-summary", Static).content
+                assert "15 tasks (2 arrays, 3 jobs)" in text
+
+    async def test_my_usage_shows_task_count_all_array(self) -> None:
+        """Banner shows correct count when all tasks belong to one array."""
+        from unittest.mock import patch
+
+        from stoei.app import SlurmMonitor
+
+        app = SlurmMonitor()
+        app._current_username = "alice"
+        with (
+            patch("stoei.app.check_slurm_available", return_value=(True, None)),
+            patch.object(app, "_start_refresh_worker"),
+        ):
+            async with app.run_test(size=(80, 24)):
+                users = [
+                    UserStats(
+                        username="alice",
+                        job_count=10,
+                        total_cpus=40,
+                        total_memory_gb=160.0,
+                        total_gpus=0,
+                        total_nodes=2,
+                        array_count=1,
+                        plain_job_count=0,
+                    ),
+                ]
+                app._update_my_usage_summary(users)
+                text = app.query_one("#my-usage-summary", Static).content
+                assert "10 tasks (1 array, 0 jobs)" in text
+
+    async def test_my_usage_shows_task_count_singular(self) -> None:
+        """Banner uses singular forms correctly for counts of 1."""
+        from unittest.mock import patch
+
+        from stoei.app import SlurmMonitor
+
+        app = SlurmMonitor()
+        app._current_username = "alice"
+        with (
+            patch("stoei.app.check_slurm_available", return_value=(True, None)),
+            patch.object(app, "_start_refresh_worker"),
+        ):
+            async with app.run_test(size=(80, 24)):
+                users = [
+                    UserStats(
+                        username="alice",
+                        job_count=1,
+                        total_cpus=4,
+                        total_memory_gb=16.0,
+                        total_gpus=0,
+                        total_nodes=1,
+                        array_count=0,
+                        plain_job_count=1,
+                    ),
+                ]
+                app._update_my_usage_summary(users)
+                text = app.query_one("#my-usage-summary", Static).content
+                assert "1 task (0 arrays, 1 job)" in text


### PR DESCRIPTION
Add `array_count` and `plain_job_count` to `UserStats`, classify each running job by its JobID (`_[` = pending array ignored, `_` = array task, else plain job), and append a task-count segment to the My Usage banner:

```
My Usage: 48 CPUs | 192.0 GB | 4 GPUs (4x H100) | 3 Nodes | 100 tasks (1 array, 0 jobs)
```

Also fixes test suite performance: mocking `get_energy_job_history` in `TestRefreshDataAsync` (user settings had energy enabled, causing ~50s SLURM timeouts per test) and adding `no_retry_sleep` fixtures to command error-path tests to eliminate backoff delays. Suite runs in ~70s instead of ~13 minutes.