### PR TITLE
feat: set terminal/tmux tab title to "stoei"

### DIFF
--- a/docs/plans/2026-03-24-feat-set-terminal-title-to-stoei-plan.md
+++ b/docs/plans/2026-03-24-feat-set-terminal-title-to-stoei-plan.md
@@ -1,0 +1,88 @@
+---
+title: "feat: Set terminal/tmux tab title to stoei"
+type: feat
+date: 2026-03-24
+---
+
+# Set terminal/tmux tab title to "stoei"
+
+## Overview
+
+When running `stoei`, the tmux tab (and terminal title bar) shows "python3" because that's the interpreter name. This change sets the terminal title to "stoei" on startup and restores default title behavior on exit.
+
+## Proposed Solution
+
+Add two functions in `stoei/__main__.py` following the existing `_ensure_truecolor()` pattern:
+
+- `_set_terminal_title(title: str)` — emits escape sequences to set the title
+- `_restore_terminal_title()` — emits empty title sequences to restore default behavior
+
+Call them in `run()` with a try/finally around the `main()` call.
+
+## Technical Approach
+
+### Escape sequences
+
+Emit **both** of the following:
+
+1. **OSC 2** (`\033]2;stoei\033\\`) — standard xterm window title, works in most terminal emulators
+2. **tmux window name** (`\033kstoei\033\\`) — sets the tmux tab name in the status bar. Only emit when `$TMUX` is set.
+
+### Restore strategy
+
+On exit, emit the same sequences with an empty title string:
+- `\033]2;\033\\` — clears xterm title (terminal resumes default)
+- `\033k\033\\` — clears tmux window name (tmux resumes `automatic-rename` behavior)
+
+This avoids the need to query/save the original title (which is unreliable across terminals).
+
+### Guards
+
+- **TTY check**: Skip all escape sequences if `sys.stdout.isatty()` is `False` (piped/redirected output)
+- **Write target**: Write to `sys.stdout` and flush — safe because sequences are emitted before Textual takes over the terminal and after it returns
+
+### Placement in `run()`
+
+```
+stoei/__main__.py::run()
+```
+
+```
+1. _ensure_truecolor()
+2. _set_terminal_title("stoei")    # NEW
+3. try:
+4.     main()
+5. finally:
+6.     _restore_terminal_title()   # NEW
+```
+
+The existing `except Exception` block in `run()` stays inside the try/finally, so the title is restored on both clean exit and crash.
+
+### Out of scope
+
+- Querying/saving the original terminal title (unreliable, unnecessary)
+- GNU screen support (`$STY`)
+- Title toggle on app suspend/resume
+- Re-enabling tmux `automatic-rename` via subprocess call (empty title achieves the same effect)
+
+## Acceptance Criteria
+
+- [x] Running `stoei` in tmux sets the tab name to "stoei"
+- [x] Running `stoei` in a regular terminal sets the window title to "stoei"
+- [x] Exiting stoei (clean quit or crash) restores default terminal title behavior
+- [x] No escape sequences emitted when stdout is not a TTY
+- [x] tmux-specific escape only emitted when `$TMUX` is set
+- [x] Unit tests cover: TTY vs non-TTY, tmux vs non-tmux, normal exit, exception exit
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `stoei/__main__.py` | Add `_set_terminal_title()`, `_restore_terminal_title()`, wrap `main()` call in try/finally |
+| `tests/unit/test_main.py` | Add tests for the two new functions and the try/finally behavior |
+
+## References
+
+- Existing pattern: `_ensure_truecolor()` in `stoei/__main__.py:15`
+- OSC escape sequences: [XTerm Control Sequences](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html)
+- tmux window naming: `\033k...\033\\` (DCS passthrough)

--- a/stoei/__main__.py
+++ b/stoei/__main__.py
@@ -11,6 +11,8 @@ from stoei.logger import get_logger
 
 logger = get_logger(__name__)
 
+_TITLE = "stoei"
+
 
 def _ensure_truecolor() -> None:
     """Ensure true color mode is enabled for consistent theme rendering.
@@ -28,6 +30,48 @@ def _ensure_truecolor() -> None:
     if colorterm.lower() not in ("truecolor", "24bit"):
         os.environ["COLORTERM"] = "truecolor"
         logger.debug(f"Set COLORTERM=truecolor (was: {colorterm!r})")
+
+
+def _set_terminal_title(title: str) -> None:
+    """Set the terminal and tmux tab title via escape sequences.
+
+    Emits OSC 2 (xterm window title) for all terminals, plus the tmux
+    window-name escape when running inside tmux.  No-ops when stdout
+    is not a TTY to avoid leaking escape sequences into piped output.
+
+    Args:
+        title: The title string to display.
+    """
+    if not sys.stdout.isatty():
+        return
+
+    # OSC 2 — standard xterm window title
+    sys.stdout.write(f"\033]2;{title}\033\\")
+
+    # tmux window name (only inside tmux)
+    if os.environ.get("TMUX"):
+        sys.stdout.write(f"\033k{title}\033\\")
+
+    sys.stdout.flush()
+    logger.debug(f"Set terminal title to {title!r}")
+
+
+def _restore_terminal_title() -> None:
+    """Restore the default terminal and tmux tab title.
+
+    Emits empty title sequences so the terminal (and tmux) resume their
+    default title behaviour (e.g. tmux re-enables automatic-rename).
+    """
+    if not sys.stdout.isatty():
+        return
+
+    sys.stdout.write("\033]2;\033\\")
+
+    if os.environ.get("TMUX"):
+        sys.stdout.write("\033k\033\\")
+
+    sys.stdout.flush()
+    logger.debug("Restored terminal title")
 
 
 def get_version() -> str:
@@ -70,6 +114,9 @@ def run() -> None:
     # Ensure true color mode for consistent theme colors
     _ensure_truecolor()
 
+    # Set terminal/tmux tab title
+    _set_terminal_title(_TITLE)
+
     try:
         main()
     except Exception:
@@ -77,6 +124,8 @@ def run() -> None:
         # Print standard Python traceback instead of Rich's fancy one
         traceback.print_exc()
         sys.exit(1)
+    finally:
+        _restore_terminal_title()
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -2,7 +2,7 @@
 
 import argparse
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 
 class TestGetVersion:
@@ -80,6 +80,140 @@ class TestRunFunction:
 
             run()
             mock_traceback.assert_called_once()
+
+
+class TestSetTerminalTitle:
+    """Tests for the _set_terminal_title() function."""
+
+    def test_emits_osc2_when_tty(self) -> None:
+        """Test that OSC 2 escape is emitted when stdout is a TTY."""
+        from stoei.__main__ import _set_terminal_title
+
+        mock_stdout = MagicMock()
+        mock_stdout.isatty.return_value = True
+        with (
+            patch("stoei.__main__.sys.stdout", mock_stdout),
+            patch.dict(os.environ, {}, clear=False),
+        ):
+            os.environ.pop("TMUX", None)
+            _set_terminal_title("stoei")
+
+        mock_stdout.write.assert_called_once_with("\033]2;stoei\033\\")
+        mock_stdout.flush.assert_called_once()
+
+    def test_emits_tmux_escape_when_in_tmux(self) -> None:
+        """Test that tmux window-name escape is also emitted inside tmux."""
+        from stoei.__main__ import _set_terminal_title
+
+        mock_stdout = MagicMock()
+        mock_stdout.isatty.return_value = True
+        with (
+            patch("stoei.__main__.sys.stdout", mock_stdout),
+            patch.dict(os.environ, {"TMUX": "tmux-socket,1234,0"}),
+        ):
+            _set_terminal_title("stoei")
+
+        assert mock_stdout.write.call_args_list == [
+            call("\033]2;stoei\033\\"),
+            call("\033kstoei\033\\"),
+        ]
+        mock_stdout.flush.assert_called_once()
+
+    def test_noop_when_not_tty(self) -> None:
+        """Test that nothing is written when stdout is not a TTY."""
+        from stoei.__main__ import _set_terminal_title
+
+        mock_stdout = MagicMock()
+        mock_stdout.isatty.return_value = False
+        with patch("stoei.__main__.sys.stdout", mock_stdout):
+            _set_terminal_title("stoei")
+
+        mock_stdout.write.assert_not_called()
+        mock_stdout.flush.assert_not_called()
+
+
+class TestRestoreTerminalTitle:
+    """Tests for the _restore_terminal_title() function."""
+
+    def test_emits_empty_osc2_when_tty(self) -> None:
+        """Test that an empty OSC 2 escape is emitted when stdout is a TTY."""
+        from stoei.__main__ import _restore_terminal_title
+
+        mock_stdout = MagicMock()
+        mock_stdout.isatty.return_value = True
+        with (
+            patch("stoei.__main__.sys.stdout", mock_stdout),
+            patch.dict(os.environ, {}, clear=False),
+        ):
+            os.environ.pop("TMUX", None)
+            _restore_terminal_title()
+
+        mock_stdout.write.assert_called_once_with("\033]2;\033\\")
+        mock_stdout.flush.assert_called_once()
+
+    def test_emits_empty_tmux_escape_when_in_tmux(self) -> None:
+        """Test that empty tmux escape is also emitted inside tmux."""
+        from stoei.__main__ import _restore_terminal_title
+
+        mock_stdout = MagicMock()
+        mock_stdout.isatty.return_value = True
+        with (
+            patch("stoei.__main__.sys.stdout", mock_stdout),
+            patch.dict(os.environ, {"TMUX": "tmux-socket,1234,0"}),
+        ):
+            _restore_terminal_title()
+
+        assert mock_stdout.write.call_args_list == [
+            call("\033]2;\033\\"),
+            call("\033k\033\\"),
+        ]
+
+    def test_noop_when_not_tty(self) -> None:
+        """Test that nothing is written when stdout is not a TTY."""
+        from stoei.__main__ import _restore_terminal_title
+
+        mock_stdout = MagicMock()
+        mock_stdout.isatty.return_value = False
+        with patch("stoei.__main__.sys.stdout", mock_stdout):
+            _restore_terminal_title()
+
+        mock_stdout.write.assert_not_called()
+
+
+class TestRunTerminalTitle:
+    """Tests for terminal title integration in run()."""
+
+    def test_run_restores_title_on_normal_exit(self) -> None:
+        """Test that run() restores the terminal title after normal exit."""
+        with (
+            patch("stoei.__main__.main"),
+            patch("stoei.__main__._ensure_truecolor"),
+            patch("stoei.__main__.parse_args", return_value=MagicMock()),
+            patch("stoei.__main__._set_terminal_title") as mock_set,
+            patch("stoei.__main__._restore_terminal_title") as mock_restore,
+        ):
+            from stoei.__main__ import run
+
+            run()
+            mock_set.assert_called_once_with("stoei")
+            mock_restore.assert_called_once()
+
+    def test_run_restores_title_on_exception(self) -> None:
+        """Test that run() restores the terminal title even when main() raises."""
+        with (
+            patch("stoei.__main__.main", side_effect=RuntimeError("boom")),
+            patch("stoei.__main__._ensure_truecolor"),
+            patch("stoei.__main__.parse_args", return_value=MagicMock()),
+            patch("stoei.__main__._set_terminal_title") as mock_set,
+            patch("stoei.__main__._restore_terminal_title") as mock_restore,
+            patch("stoei.__main__.traceback.print_exc"),
+            patch("stoei.__main__.sys.exit"),
+        ):
+            from stoei.__main__ import run
+
+            run()
+            mock_set.assert_called_once_with("stoei")
+            mock_restore.assert_called_once()
 
 
 class TestEnsureTruecolor:


### PR DESCRIPTION
## Summary

- Sets the terminal title bar and tmux tab name to "stoei" on startup using OSC 2 escape sequences (plus tmux-specific `\033k...\033\\` when `$TMUX` is set)
- Restores default title behavior on exit via `try/finally`, covering both clean exits and crashes
- No-ops when stdout is not a TTY to avoid leaking escape sequences into piped output
- Adds 8 unit tests covering TTY/non-TTY, tmux/non-tmux, and restore-on-exception scenarios