### PR TITLE
fix: sync job detail modal with live state and decouple running-jobs refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ I want to have a clear code structure. In the end, I want the main source code f
 ## Code style
 
 - **All imports must be hoisted to the top of the file** - no imports inside functions, methods, or conditional blocks. This is enforced by ruff rule PLC0415.
+- **Do not use `if TYPE_CHECKING:` blocks.** Import everything as a regular top-level runtime import. If a runtime import would be circular, fix the underlying coupling - for example, move shared data models into a small dependency-free module that both sides can import (see `stoei/usage_stats.py`). Only when neither a runtime import nor a small refactor is viable (a genuinely type-only third-party symbol, or accessing a concrete `App` subclass attribute through Textual's `self.app`), suppress the specific diagnostic inline with `# ty: ignore[<rule>]` instead of reintroducing `TYPE_CHECKING`.
 
 ## Agent Auto-run Commands
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=6.0.0",
     "ruff>=0.8.2",
-    "ty>=0.0.1a6",
+    "ty==0.0.42",
     "pre-commit>=4.0.1",
 ]
 
@@ -113,5 +113,5 @@ dev = [
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
     "ruff>=0.14.13",
-    "ty>=0.0.12",
+    "ty==0.0.42",
 ]

--- a/stoei/app.py
+++ b/stoei/app.py
@@ -88,7 +88,7 @@ from stoei.widgets.screens import (
 )
 from stoei.widgets.settings_screen import SettingsScreen
 from stoei.widgets.slurm_error_screen import SlurmUnavailableScreen
-from stoei.widgets.tabs import TabContainer, TabSwitched
+from stoei.widgets.tabs import TabContainer, TabName, TabSwitched
 from stoei.widgets.user_overview import (
     UserEnergyStats,
     UserOverviewTab,
@@ -259,7 +259,7 @@ class SlurmMonitor(App[None]):
         self._error_notified: dict[str, bool] = {}
         # Tab switch debouncing: rapid key presses within the same event-loop
         # frame are batched so only the final tab is actually switched to.
-        self._pending_tab_switch: str | None = None
+        self._pending_tab_switch: TabName | None = None
         self._tab_switch_scheduled: bool = False
         self._init_update_generation_counters()
 
@@ -2309,7 +2309,7 @@ class SlurmMonitor(App[None]):
         except Exception as exc:
             logger.error(f"Failed to update energy UI: {exc}", exc_info=True)
 
-    def _switch_tab(self, tab_name: str) -> None:
+    def _switch_tab(self, tab_name: TabName) -> None:
         """Debounced tab switch.
 
         Multiple calls within the same event-loop frame are batched: only
@@ -2360,7 +2360,7 @@ class SlurmMonitor(App[None]):
         """Switch to the Logs tab."""
         self._switch_tab("logs")
 
-    def _resolve_base_tab(self) -> str:
+    def _resolve_base_tab(self) -> TabName:
         """Return the tab name to use as base for next/previous cycling.
 
         If a debounced switch is pending, use that so rapid Tab presses
@@ -2379,7 +2379,7 @@ class SlurmMonitor(App[None]):
         """Switch to the next tab (cycling)."""
         if not self._initial_load_complete:
             return
-        tab_order = ["jobs", "nodes", "users", "priority", "logs"]
+        tab_order: list[TabName] = ["jobs", "nodes", "users", "priority", "logs"]
         base = self._resolve_base_tab()
         current_index = tab_order.index(base) if base in tab_order else 0
         self._switch_tab(tab_order[(current_index + 1) % len(tab_order)])
@@ -2388,7 +2388,7 @@ class SlurmMonitor(App[None]):
         """Switch to the previous tab (cycling)."""
         if not self._initial_load_complete:
             return
-        tab_order = ["jobs", "nodes", "users", "priority", "logs"]
+        tab_order: list[TabName] = ["jobs", "nodes", "users", "priority", "logs"]
         base = self._resolve_base_tab()
         current_index = tab_order.index(base) if base in tab_order else 0
         self._switch_tab(tab_order[(current_index - 1) % len(tab_order)])

--- a/stoei/app.py
+++ b/stoei/app.py
@@ -1007,9 +1007,10 @@ class SlurmMonitor(App[None]):
             running_jobs, history_jobs, total_jobs, total_requeues, max_requeues = cast(_UserJobsResult, result)
             if running_jobs is not None:
                 self._error_notified["running_jobs"] = False
-                old_job_ids = {j.job_id for j in self._job_cache.jobs}
+                old_states = self._job_states()
                 self._handle_refresh_fallback(running_jobs, history_jobs, total_jobs, total_requeues, max_requeues)
-                self._notify_new_jobs(old_job_ids)
+                self._notify_new_jobs(set(old_states))
+                self._invalidate_changed_job_info(old_states)
             else:
                 if not self._error_notified.get("running_jobs"):
                     self._error_notified["running_jobs"] = True
@@ -1190,7 +1191,6 @@ class SlurmMonitor(App[None]):
         Args:
             is_first_cycle: Whether this was the first background refresh cycle.
         """
-        self._job_info_cache.clear()
         if is_first_cycle:
             self._initial_background_complete = True
             self.auto_refresh_timer = self.set_interval(self.refresh_interval, self._start_refresh_worker)
@@ -1256,6 +1256,32 @@ class SlurmMonitor(App[None]):
         else:
             msg = f"{len(new_active_jobs)} new jobs detected"
         self._post_ui_callback(lambda m=msg: self.notify(m, timeout=5, severity="information"))
+
+    def _job_states(self) -> dict[str, str]:
+        """Return a snapshot mapping each cached job's ID to its current state."""
+        return {job.job_id: job.state for job in self._job_cache.jobs}
+
+    def _invalidate_changed_job_info(self, old_states: dict[str, str]) -> None:
+        """Evict cached modal job-info for jobs whose state changed (worker thread).
+
+        Compares each job's state before and after the cache rebuild. Any job
+        whose state changed - or that disappeared from the cache - has its cached
+        ``scontrol``/``sacct`` detail evicted so the next modal open re-fetches
+        it; unchanged jobs keep their cached entry for instant display. Eviction
+        is conservative: array tasks that share a normalized cache key are
+        evicted together when any one of them changes.
+
+        Called from ``_apply_fetch_result`` right after the cache rebuild, so the
+        modal cache stays consistent with the table cache it was derived from
+        instead of being gated behind full-cycle completion.
+
+        Args:
+            old_states: Job-ID-to-state snapshot captured before the rebuild.
+        """
+        new_states = self._job_states()
+        for job_id, old_state in old_states.items():
+            if new_states.get(job_id) != old_state:
+                self._job_info_cache.pop(normalize_array_job_id(job_id), None)
 
     def _set_loading_indicator(self, active: bool) -> None:
         """Safely toggle the global loading indicator spinner."""

--- a/stoei/app.py
+++ b/stoei/app.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import replace
 from pathlib import Path
+from threading import Lock
 from typing import ClassVar, TypeAlias, cast
 
 from textual._path import CSSPathType
@@ -98,12 +99,17 @@ from stoei.widgets.user_overview import (
 logger = get_logger(__name__)
 
 # Type aliases for fetch result types used in _apply_fetch_result.
-_UserJobsResult: TypeAlias = tuple[list[tuple[str, ...]] | None, list[tuple[str, ...]] | None, int, int, int]
+_HistoryResult: TypeAlias = tuple[list[tuple[str, ...]] | None, int, int, int]
 _PriorityHalfResult: TypeAlias = tuple[list[tuple[str, ...]], str | None]
 _EnergyResult: TypeAlias = tuple[list[tuple[str, ...]], bool]
 _FetchResult: TypeAlias = (
-    _UserJobsResult | list[dict[str, str]] | list[tuple[str, ...]] | _PriorityHalfResult | _EnergyResult
+    _HistoryResult | list[dict[str, str]] | list[tuple[str, ...]] | _PriorityHalfResult | _EnergyResult
 )
+
+# The heavy data loop (history, nodes, all-users jobs, wait times, priority) refreshes
+# at this multiple of the base refresh interval. Slow sacct/sshare/sprio calls then never
+# gate the fast running-jobs loop that drives the jobs-table "Time" column.
+HEAVY_REFRESH_MULTIPLIER = 4
 
 # Path to styles directory
 STYLES_DIR = Path(__file__).parent / "styles"
@@ -204,10 +210,7 @@ class SlurmMonitor(App[None]):
         super().__init__()
         self._register_custom_themes()
         self._apply_theme(self._settings.theme)
-        self.refresh_interval: float = self._settings.refresh_interval
-        self.auto_refresh_timer: Timer | None = None
-        self._job_cache: JobCache = JobCache()
-        self._refresh_worker: Worker[None] | None = None
+        self._init_refresh_state()
         self._initial_load_complete: bool = False
         self._current_username: str = get_current_username()
         self._log_sink_id: int | None = None
@@ -220,8 +223,6 @@ class SlurmMonitor(App[None]):
         self._job_priority_entries: list[tuple[str, ...]] = []  # Pending job priority data from sprio
         self._is_narrow: bool = False
         self._loading_screen: LoadingScreen | None = None
-        self._last_history_jobs: list[tuple[str, ...]] = []
-        self._last_history_stats: tuple[int, int, int] = (0, 0, 0)
         self._keybindings: KeybindingConfig = self._settings.get_keybindings()
         # Tracks whether the first background refresh cycle (which loads non-critical
         # data like nodes, all-users jobs, energy, etc.) has completed.
@@ -261,6 +262,27 @@ class SlurmMonitor(App[None]):
         self._pending_tab_switch: str | None = None
         self._tab_switch_scheduled: bool = False
         self._init_update_generation_counters()
+
+    def _init_refresh_state(self) -> None:
+        """Initialise the data-refresh state: timers, workers, cache, and snapshots.
+
+        The app runs two refresh loops: a fast running-jobs loop (squeue, drives
+        the jobs-table "Time" column) and a slow heavy loop (history, nodes,
+        priority, ...). Each loop rebuilds the shared job cache from its own fresh
+        data plus the other loop's last-known snapshot, serialized by a lock.
+        """
+        self.refresh_interval: float = self._settings.refresh_interval
+        self.auto_refresh_timer: Timer | None = None
+        self.heavy_refresh_timer: Timer | None = None
+        self._job_cache: JobCache = JobCache()
+        self._refresh_worker: Worker[None] | None = None
+        self._running_refresh_worker: Worker[None] | None = None
+        # Serializes job-cache rebuilds between the fast running-jobs loop and the
+        # slow history loop so their _build_from_data calls never interleave.
+        self._refresh_state_lock = Lock()
+        self._last_running_jobs: list[tuple[str, ...]] = []
+        self._last_history_jobs: list[tuple[str, ...]] = []
+        self._last_history_stats: tuple[int, int, int] = (0, 0, 0)
 
     def _init_update_generation_counters(self) -> None:
         """Initialise generation counters for deferred UI updates.
@@ -418,7 +440,9 @@ class SlurmMonitor(App[None]):
 
         running_jobs, history_jobs, total_jobs, total_requeues, max_requeues = load_result
 
-        # Save initial history for fallback
+        # Save initial snapshots so each refresh loop can rebuild the table from
+        # the other loop's last-known data without re-fetching it.
+        self._last_running_jobs = running_jobs
         self._last_history_jobs = history_jobs
         self._last_history_stats = (total_jobs, total_requeues, max_requeues)
 
@@ -580,8 +604,13 @@ class SlurmMonitor(App[None]):
         # doesn't skip because it still sees the (finishing) initial worker.
         self._refresh_worker = None
 
-        # Kick off background refresh to load non-critical data (nodes, all-users
-        # jobs, energy, wait times, priority).
+        # Start the fast running-jobs loop now so the jobs-table "Time" column
+        # advances every refresh_interval, independent of the slow heavy load.
+        self.auto_refresh_timer = self.set_interval(self.refresh_interval, self._start_running_refresh_worker)
+
+        # Kick off the first heavy background load (nodes, all-users jobs, energy,
+        # wait times, priority, history). Its recurring timer starts once it
+        # completes, in _on_refresh_complete.
         logger.info("Starting background load for cluster data sources")
         self._start_refresh_worker()
 
@@ -632,11 +661,14 @@ class SlurmMonitor(App[None]):
 
         self.refresh_interval = new_interval
 
-        # Restart timer if running
+        # Restart both loops' timers if running so the new interval takes effect.
         if self.auto_refresh_timer is not None:
             self.auto_refresh_timer.stop()
-            self.auto_refresh_timer = self.set_interval(self.refresh_interval, self._start_refresh_worker)
-            logger.info(f"Refresh interval changed from {old_interval}s to {new_interval}s")
+            self.auto_refresh_timer = self.set_interval(self.refresh_interval, self._start_running_refresh_worker)
+        if self.heavy_refresh_timer is not None:
+            self.heavy_refresh_timer.stop()
+            self.heavy_refresh_timer = self.set_interval(self.heavy_refresh_interval, self._start_refresh_worker)
+        logger.info(f"Refresh interval changed from {old_interval}s to {new_interval}s")
 
     def _apply_keybind_mode(self, settings: Settings) -> None:
         """Apply keybind mode to all filterable tables.
@@ -816,10 +848,15 @@ class SlurmMonitor(App[None]):
         except Exception as exc:
             logger.warning(f"Failed to apply saved column widths for {table_name}: {exc}")
 
+    @property
+    def heavy_refresh_interval(self) -> float:
+        """Interval (seconds) for the heavy data loop (history, nodes, priority, ...)."""
+        return self.refresh_interval * HEAVY_REFRESH_MULTIPLIER
+
     def _start_refresh_worker(self) -> None:
-        """Start background worker for lightweight data refresh."""
+        """Start the heavy background worker (history, nodes, all-users jobs, priority)."""
         if self._refresh_worker is not None and self._refresh_worker.state == WorkerState.RUNNING:
-            logger.debug("Refresh worker already running, skipping")
+            logger.debug("Heavy refresh worker already running, skipping")
             return
 
         self._refresh_worker = self.run_worker(
@@ -830,32 +867,88 @@ class SlurmMonitor(App[None]):
             thread=True,
         )
 
+    def _start_running_refresh_worker(self) -> None:
+        """Start the fast worker that refreshes running jobs (drives the jobs-table Time column).
+
+        This loop fetches ``squeue`` only, so it is never gated by the slow
+        ``sacct``/``sshare``/``sprio`` calls in the heavy loop.
+        """
+        if self._running_refresh_worker is not None and self._running_refresh_worker.state == WorkerState.RUNNING:
+            logger.debug("Running-jobs refresh worker already running, skipping")
+            return
+
+        self._running_refresh_worker = self.run_worker(
+            self._refresh_running_jobs_async,
+            name="refresh_running_jobs",
+            group="running_refresh",
+            exclusive=True,
+            thread=True,
+        )
+
+    def _refresh_running_jobs_async(self) -> None:
+        """Fetch running jobs (squeue only) and refresh the jobs table (worker thread)."""
+        worker = get_current_worker()
+        running_jobs, error = get_running_jobs(max_retries=1)
+        if worker.is_cancelled:
+            return
+        if error:
+            logger.warning(f"Failed to refresh running jobs: {error}")
+            self._apply_running_jobs_result(None)
+        else:
+            self._apply_running_jobs_result(running_jobs)
+
+    def _apply_running_jobs_result(self, running_jobs: list[tuple[str, ...]] | None) -> None:
+        """Rebuild the jobs table from fresh running jobs + cached history (worker thread).
+
+        On a fetch failure (``running_jobs is None``) the previous table is kept
+        and the user is notified once. On success the running-jobs snapshot is
+        updated and the table is rebuilt against the last-known history snapshot,
+        so the "Time" column advances without waiting on the heavy history loop.
+
+        Args:
+            running_jobs: Fresh squeue job tuples, or None if the fetch failed.
+        """
+        if running_jobs is None:
+            if not self._error_notified.get("running_jobs"):
+                self._error_notified["running_jobs"] = True
+                self._post_ui_callback(
+                    lambda: self.notify("Running jobs refresh failed - keeping old data", severity="warning")
+                )
+            return
+
+        self._error_notified["running_jobs"] = False
+        with self._refresh_state_lock:
+            self._last_running_jobs = running_jobs
+            old_states = self._job_states()
+            total_jobs, total_requeues, max_requeues = self._last_history_stats
+            self._job_cache._build_from_data(
+                running_jobs, self._last_history_jobs, total_jobs, total_requeues, max_requeues
+            )
+            self._notify_new_jobs(set(old_states))
+            self._invalidate_changed_job_info(old_states)
+            job_rows = self._current_job_rows()
+        self._post_ui_callback(lambda: self._update_jobs_table(job_rows))
+
+    def _current_job_rows(self) -> list[tuple[str, ...]]:
+        """Snapshot the cached jobs as display-ready table rows."""
+        return [tuple(self._job_row_values(job)) for job in self._sorted_jobs_for_display(self._job_cache.jobs)]
+
     # --- Parallel fetch helpers (run inside ThreadPoolExecutor threads) ---
 
-    def _fetch_user_jobs(self) -> tuple[list[tuple[str, ...]] | None, list[tuple[str, ...]] | None, int, int, int]:
-        """Fetch user's running jobs and history.
+    def _fetch_history(self) -> _HistoryResult:
+        """Fetch the user's job history (sacct) for the heavy refresh loop.
 
         Returns:
-            Tuple of (running_jobs, history_jobs, total_jobs, total_requeues, max_requeues).
+            Tuple of (history_jobs, total_jobs, total_requeues, max_requeues).
+            ``history_jobs`` is None if the fetch failed.
         """
-        running_jobs: list[tuple[str, ...]] | None
-        running_raw, r_error = get_running_jobs()
-        if r_error:
-            logger.warning(f"Failed to refresh running jobs: {r_error}")
-            running_jobs = None
-        else:
-            running_jobs = running_raw
-
-        history_jobs: list[tuple[str, ...]] | None
-        job_history_days = self._settings.job_history_days
-        history_raw, total_jobs, total_requeues, max_requeues, h_error = get_job_history(days=job_history_days)
+        history_raw, total_jobs, total_requeues, max_requeues, h_error = get_job_history(
+            days=self._settings.job_history_days
+        )
         if h_error:
             logger.warning(f"Failed to refresh job history: {h_error}")
-            history_jobs = None
-        else:
-            history_jobs = history_raw
-
-        return running_jobs, history_jobs, total_jobs, total_requeues, max_requeues
+            return None, 0, 0, 0
+        return history_raw, total_jobs, total_requeues, max_requeues
 
     def _fetch_nodes(self) -> list[dict[str, str]]:
         """Fetch cluster node data.
@@ -932,7 +1025,7 @@ class SlurmMonitor(App[None]):
             max_workers = 7 if is_first_cycle else 6
             with ThreadPoolExecutor(max_workers=max_workers) as pool:
                 futures: dict[Future[object], str] = {
-                    pool.submit(self._fetch_user_jobs): "user_jobs",
+                    pool.submit(self._fetch_history): "history",
                     pool.submit(self._fetch_nodes): "nodes",
                     pool.submit(self._fetch_all_jobs): "all_jobs",
                     pool.submit(self._fetch_wait_time): "wait_time",
@@ -962,37 +1055,6 @@ class SlurmMonitor(App[None]):
         finally:
             self._post_ui_callback(lambda: self._set_loading_indicator(False))
 
-    def _process_refresh_results(self, results: dict[str, object]) -> None:
-        """Process a batch of fetch results, updating error-notification state (worker thread).
-
-        Handles the ``user_jobs`` label: tracks running-jobs failure notifications
-        and delegates to :meth:`_handle_refresh_fallback` for history fallback.
-        Unlike :meth:`_apply_fetch_result`, this method does **not** schedule a
-        job-table UI update so it can be used in contexts where the table refresh
-        is driven separately.
-
-        Args:
-            results: Mapping of fetch label to its result value.
-        """
-        if "user_jobs" not in results:
-            return
-        running_jobs, history_jobs, total_jobs, total_requeues, max_requeues = cast(
-            _UserJobsResult, results["user_jobs"]
-        )
-        if running_jobs is not None:
-            self._error_notified["running_jobs"] = False
-            self._handle_refresh_fallback(running_jobs, history_jobs, total_jobs, total_requeues, max_requeues)
-        else:
-            if not self._error_notified.get("running_jobs"):
-                self._error_notified["running_jobs"] = True
-                self._post_ui_callback(
-                    lambda: self.notify("Running jobs refresh failed - keeping old data", severity="warning")
-                )
-            if history_jobs is not None:
-                self._error_notified["history_jobs"] = False
-                self._last_history_jobs = history_jobs
-                self._last_history_stats = (total_jobs, total_requeues, max_requeues)
-
     def _apply_fetch_result(self, label: str, result: _FetchResult) -> None:  # noqa: PLR0912, PLR0915
         """Process one completed fetch and push a partial UI update (worker thread).
 
@@ -1003,25 +1065,15 @@ class SlurmMonitor(App[None]):
             label: Fetch label identifying the data source.
             result: The data returned by the fetch function.
         """
-        if label == "user_jobs":
-            running_jobs, history_jobs, total_jobs, total_requeues, max_requeues = cast(_UserJobsResult, result)
-            if running_jobs is not None:
-                self._error_notified["running_jobs"] = False
+        if label == "history":
+            history_jobs, total_jobs, total_requeues, max_requeues = cast(_HistoryResult, result)
+            with self._refresh_state_lock:
                 old_states = self._job_states()
-                self._handle_refresh_fallback(running_jobs, history_jobs, total_jobs, total_requeues, max_requeues)
-                self._notify_new_jobs(set(old_states))
+                self._handle_refresh_fallback(
+                    self._last_running_jobs, history_jobs, total_jobs, total_requeues, max_requeues
+                )
                 self._invalidate_changed_job_info(old_states)
-            else:
-                if not self._error_notified.get("running_jobs"):
-                    self._error_notified["running_jobs"] = True
-                    self._post_ui_callback(
-                        lambda: self.notify("Running jobs refresh failed - keeping old data", severity="warning")
-                    )
-                if history_jobs is not None:
-                    self._error_notified["history_jobs"] = False
-                    self._last_history_jobs = history_jobs
-                    self._last_history_stats = (total_jobs, total_requeues, max_requeues)
-            job_rows = [tuple(self._job_row_values(j)) for j in self._sorted_jobs_for_display(self._job_cache.jobs)]
+                job_rows = self._current_job_rows()
             self._post_ui_callback(lambda: self._update_jobs_table(job_rows))
 
         elif label == "nodes":
@@ -1185,21 +1237,23 @@ class SlurmMonitor(App[None]):
     def _on_refresh_complete(self, is_first_cycle: bool) -> None:
         """Handle post-refresh bookkeeping (main thread only).
 
-        On the first cycle this starts the auto-refresh timer and notifies
-        the user that all cluster data has been loaded.
+        On the first cycle this starts the recurring heavy-refresh timer and
+        notifies the user that all cluster data has been loaded. The fast
+        running-jobs timer is already started in :meth:`_finish_initial_load`.
 
         Args:
             is_first_cycle: Whether this was the first background refresh cycle.
         """
         if is_first_cycle:
             self._initial_background_complete = True
-            self.auto_refresh_timer = self.set_interval(self.refresh_interval, self._start_refresh_worker)
+            self.heavy_refresh_timer = self.set_interval(self.heavy_refresh_interval, self._start_refresh_worker)
             self.notify("Cluster data ready", timeout=3, severity="information")
             logger.info(
-                f"Background initial load complete. Auto-refresh started with interval {self.refresh_interval}s"
+                f"Background initial load complete. Running-jobs refresh every {self.refresh_interval}s, "
+                f"heavy refresh every {self.heavy_refresh_interval}s"
             )
         else:
-            logger.debug("Refresh cycle complete - all data sources updated")
+            logger.debug("Heavy refresh cycle complete - all data sources updated")
 
     def _handle_refresh_fallback(
         self,
@@ -2198,10 +2252,11 @@ class SlurmMonitor(App[None]):
                 logger.warning(f"Failed to handle tab switch to {event.tab_name}: {exc}")
 
     def action_refresh(self) -> None:
-        """Manual refresh action."""
+        """Manual refresh action (refreshes both the running-jobs and heavy loops)."""
         logger.info("Manual refresh triggered")
         self._error_notified.clear()
         self.notify("Refreshing...")
+        self._start_running_refresh_worker()
         self._start_refresh_worker()
 
     def reload_energy_data(self) -> None:

--- a/stoei/colors.py
+++ b/stoei/colors.py
@@ -16,11 +16,7 @@ Usage:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    pass
-
+from typing import Any
 
 # Fallback colors when theme is not available (using sensible defaults)
 FALLBACK_COLORS = {

--- a/stoei/keybindings.py
+++ b/stoei/keybindings.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import ClassVar
+from typing import ClassVar, Literal
 
 from stoei.logger import get_logger
 
 logger = get_logger(__name__)
+
+# Keybinding presets the app ships with.
+KeybindMode = Literal["vim", "emacs"]
 
 
 # Action names (used as keys in binding maps)
@@ -261,7 +264,7 @@ PRESETS: dict[str, KeybindingPreset] = {
     "emacs": _create_emacs_preset(),
 }
 
-DEFAULT_PRESET = "vim"
+DEFAULT_PRESET: KeybindMode = "vim"
 
 
 @dataclass
@@ -383,7 +386,7 @@ class KeybindingConfig:
         return cls(preset=preset, overrides=overrides)
 
 
-def get_default_config(mode: str = "vim") -> KeybindingConfig:
+def get_default_config(mode: KeybindMode = "vim") -> KeybindingConfig:
     """Get a default keybinding configuration for a mode.
 
     Args:

--- a/stoei/logger.py
+++ b/stoei/logger.py
@@ -8,12 +8,10 @@ import os
 from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol
+from typing import Protocol
 
+import loguru
 from loguru import logger
-
-if TYPE_CHECKING:
-    import loguru
 
 
 class LoguruLevel(Protocol):

--- a/stoei/settings.py
+++ b/stoei/settings.py
@@ -7,15 +7,17 @@ import os
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal, cast
 
-from stoei.keybindings import DEFAULT_PRESET, KeybindingConfig
+from stoei.keybindings import DEFAULT_PRESET, KeybindingConfig, KeybindMode
 from stoei.logger import get_logger
 from stoei.themes import DEFAULT_THEME_NAME, THEME_LABELS
 
 logger = get_logger(__name__)
 
-LOG_LEVELS: tuple[str, ...] = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
-KEYBIND_MODES: tuple[str, ...] = ("vim", "emacs")
+LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+LOG_LEVELS: tuple[LogLevel, ...] = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
+KEYBIND_MODES: tuple[KeybindMode, ...] = ("vim", "emacs")
 DEFAULT_KEYBIND_MODE = DEFAULT_PRESET
 MIN_LOG_LINES = 200
 DEFAULT_MAX_LOG_LINES = 2000
@@ -49,12 +51,12 @@ class Settings:
     """User-configurable settings stored on disk."""
 
     theme: str = DEFAULT_THEME_NAME
-    log_level: str = "WARNING"
+    log_level: LogLevel = "WARNING"
     max_log_lines: int = DEFAULT_MAX_LOG_LINES
     refresh_interval: float = DEFAULT_REFRESH_INTERVAL
     job_history_days: int = DEFAULT_JOB_HISTORY_DAYS
     log_viewer_lines: int = DEFAULT_LOG_VIEWER_LINES
-    keybind_mode: str = DEFAULT_KEYBIND_MODE
+    keybind_mode: KeybindMode = DEFAULT_KEYBIND_MODE
     # Store keybinding overrides as tuple of (action, key) pairs (hashable for frozen dataclass)
     keybind_overrides: tuple[tuple[str, str], ...] = ()
     # Energy loading settings (disabled by default to speed up startup)
@@ -90,7 +92,11 @@ class Settings:
         theme = theme_value if theme_value is not None and theme_value in THEME_LABELS else DEFAULT_THEME_NAME
 
         log_level_value = _coerce_str(data.get("log_level"))
-        log_level = log_level_value if log_level_value is not None and log_level_value in LOG_LEVELS else "WARNING"
+        log_level: LogLevel = (
+            cast("LogLevel", log_level_value)
+            if log_level_value is not None and log_level_value in LOG_LEVELS
+            else "WARNING"
+        )
 
         max_log_lines = _coerce_int(data.get("max_log_lines"))
         if max_log_lines is None or max_log_lines < MIN_LOG_LINES:
@@ -121,8 +127,8 @@ class Settings:
             log_viewer_lines = DEFAULT_LOG_VIEWER_LINES
 
         keybind_mode_value = _coerce_str(data.get("keybind_mode"))
-        keybind_mode = (
-            keybind_mode_value
+        keybind_mode: KeybindMode = (
+            cast("KeybindMode", keybind_mode_value)
             if keybind_mode_value is not None and keybind_mode_value in KEYBIND_MODES
             else DEFAULT_KEYBIND_MODE
         )

--- a/stoei/slurm/formatters.py
+++ b/stoei/slurm/formatters.py
@@ -5,16 +5,13 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING
 
 from stoei.colors import FALLBACK_COLORS, ThemeColors
 from stoei.slurm.energy import ENERGY_KWH_THRESHOLD, ENERGY_MWH_THRESHOLD
 from stoei.slurm.gpu_parser import calculate_total_gpus
 from stoei.slurm.nodelist import expand_nodelist
 from stoei.slurm.parser import parse_scontrol_output, parse_tres_resources
-
-if TYPE_CHECKING:
-    from stoei.widgets.user_overview import UserEnergyStats, UserPendingStats, UserStats
+from stoei.usage_stats import UserEnergyStats, UserPendingStats, UserStats
 
 
 def _get_default_colors() -> ThemeColors:

--- a/stoei/slurm/parser.py
+++ b/stoei/slurm/parser.py
@@ -1,12 +1,8 @@
 """Parsers for SLURM command output."""
 
 import re
-from typing import TYPE_CHECKING
 
 from stoei.slurm.gpu_parser import parse_gpu_entries
-
-if TYPE_CHECKING:
-    pass
 
 # Constants for parsing
 MIN_SQUEUE_PARTS = 8  # JobID, Name, State, Time, Nodes, NodeList, SubmitTime, StartTime

--- a/stoei/usage_stats.py
+++ b/stoei/usage_stats.py
@@ -1,0 +1,47 @@
+"""Shared user resource-usage data models.
+
+These dataclasses are consumed by both the SLURM formatters and the user
+overview widget. They live in a dependency-free module so either side can
+import them without creating an import cycle.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class UserStats:
+    """User resource usage statistics."""
+
+    username: str
+    job_count: int
+    total_cpus: int
+    total_memory_gb: float
+    total_gpus: int
+    total_nodes: int
+    gpu_types: str = ""
+    node_names: str = ""
+    array_count: int = 0
+    plain_job_count: int = 0
+
+
+@dataclass
+class UserPendingStats:
+    """User pending job resource statistics."""
+
+    username: str
+    pending_job_count: int
+    pending_cpus: int
+    pending_memory_gb: float
+    pending_gpus: int
+    pending_gpu_types: str = ""
+
+
+@dataclass
+class UserEnergyStats:
+    """User energy usage statistics over a historical period."""
+
+    username: str
+    total_energy_wh: float  # Total energy in Watt-hours
+    job_count: int  # Number of completed jobs
+    gpu_hours: float  # Total GPU-hours used
+    cpu_hours: float  # Total CPU-hours used

--- a/stoei/widgets/filterable_table.py
+++ b/stoei/widgets/filterable_table.py
@@ -6,7 +6,7 @@ import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import Any, ClassVar
 
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -16,13 +16,10 @@ from textual.events import Key
 from textual.message import Message
 from textual.reactive import reactive
 from textual.widgets import DataTable, Input, Static
-from textual.widgets.data_table import ColumnKey, RowKey
+from textual.widgets.data_table import CellType, ColumnKey, RowKey
 
 from stoei.keybindings import Actions, KeybindingConfig, get_default_config
 from stoei.logger import get_logger
-
-if TYPE_CHECKING:
-    from textual.widgets.data_table import CellType
 
 logger = get_logger(__name__)
 
@@ -995,7 +992,7 @@ class FilterableDataTable(Vertical):
 
         for col_config in self._columns:
             try:
-                column = table.columns.get(col_config.key)  # type: ignore[arg-type]
+                column = table.columns.get(ColumnKey(col_config.key))
                 if column is not None and column.width is not None:
                     widths[col_config.key] = column.width
             except Exception:
@@ -1013,7 +1010,7 @@ class FilterableDataTable(Vertical):
 
         for col_key, col_width in widths.items():
             try:
-                column = table.columns.get(col_key)  # type: ignore[arg-type]
+                column = table.columns.get(ColumnKey(col_key))
                 if column is not None:
                     # Find the column config to get min/max constraints
                     col_config = next((c for c in self._columns if c.key == col_key), None)

--- a/stoei/widgets/filterable_table.py
+++ b/stoei/widgets/filterable_table.py
@@ -18,7 +18,7 @@ from textual.reactive import reactive
 from textual.widgets import DataTable, Input, Static
 from textual.widgets.data_table import CellType, ColumnKey, RowKey
 
-from stoei.keybindings import Actions, KeybindingConfig, get_default_config
+from stoei.keybindings import Actions, KeybindingConfig, KeybindMode, get_default_config
 from stoei.logger import get_logger
 
 logger = get_logger(__name__)
@@ -171,7 +171,7 @@ class FilterableDataTable(Vertical):
         self,
         *,
         columns: list[ColumnConfig] | None = None,
-        keybind_mode: str = "vim",
+        keybind_mode: KeybindMode = "vim",
         keybindings: KeybindingConfig | None = None,
         table_id: str | None = None,
         name: str | None = None,
@@ -264,7 +264,7 @@ class FilterableDataTable(Vertical):
         """Get the current filter state."""
         return self._filter_state
 
-    def set_keybind_mode(self, mode: str, keybindings: KeybindingConfig | None = None) -> None:
+    def set_keybind_mode(self, mode: KeybindMode, keybindings: KeybindingConfig | None = None) -> None:
         """Set the keybind mode and optionally update keybindings.
 
         Args:

--- a/stoei/widgets/log_pane.py
+++ b/stoei/widgets/log_pane.py
@@ -114,10 +114,10 @@ class LogPane(RichLog):
         if not hasattr(message, "record"):
             return
         record = message.record
-        level_obj = record["level"]  # type: ignore[index]
+        level_obj = record["level"]  # ty: ignore[not-subscriptable]
         level = level_obj.name
-        msg = record["message"]  # type: ignore[index]
-        timestamp_obj = record["time"]  # type: ignore[index]
+        msg = record["message"]  # ty: ignore[not-subscriptable]
+        timestamp_obj = record["time"]  # ty: ignore[not-subscriptable]
         timestamp = timestamp_obj.replace(tzinfo=None)
 
         # Post non-blocking message to the main thread

--- a/stoei/widgets/screens.py
+++ b/stoei/widgets/screens.py
@@ -8,7 +8,7 @@ import subprocess
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import ClassVar
+from typing import ClassVar, Literal
 
 from rich.errors import MarkupError
 from textual.app import ComposeResult, SuspendNotSupported
@@ -23,6 +23,9 @@ from stoei.logger import get_logger
 from stoei.settings import load_settings
 
 logger = get_logger(__name__)
+
+# A job log stream: standard output or standard error.
+LogType = Literal["stdout", "stderr"]
 
 # Timeout for file loading operations (in seconds)
 FILE_LOAD_TIMEOUT = 1.0
@@ -88,12 +91,12 @@ class LogViewerScreen(Screen[None]):
     # Spinner frames for loading indicator
     SPINNER_FRAMES: ClassVar[tuple[str, ...]] = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
 
-    def __init__(self, filepath: str, log_type: str, max_lines: int | None = None) -> None:
+    def __init__(self, filepath: str, log_type: LogType, max_lines: int | None = None) -> None:
         """Initialize the log viewer screen.
 
         Args:
             filepath: Path to the log file.
-            log_type: Type of log (e.g., "stdout" or "stderr").
+            log_type: Type of log ("stdout" or "stderr").
             max_lines: Maximum number of lines to display (truncates from start if exceeded).
         """
         super().__init__()
@@ -1248,12 +1251,12 @@ class JobInfoScreen(Screen[None]):
                 buttons[prev_idx].focus()
                 return
 
-    def _open_log(self, path: str | None, log_type: str) -> None:
+    def _open_log(self, path: str | None, log_type: LogType) -> None:
         """Open the log viewer screen for a log file.
 
         Args:
             path: Path to the log file.
-            log_type: Type of log (stdout or stderr).
+            log_type: Type of log ("stdout" or "stderr").
         """
         # Check if path is None, empty, or whitespace-only
         if not path or (isinstance(path, str) and not path.strip()):

--- a/stoei/widgets/settings_screen.py
+++ b/stoei/widgets/settings_screen.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import ClassVar
+from typing import ClassVar, cast
 
 from textual.app import ComposeResult
 from textual.containers import Container, Vertical
@@ -191,7 +191,7 @@ class SettingsScreen(Screen[Settings | None]):
         if event.key in ("left", "right") and isinstance(focused, Select) and not focused.expanded:
             event.stop()
             # Type narrow: we know it's a Select[str] in this screen
-            select_widget: Select[str] = focused  # type: ignore[assignment]
+            select_widget = cast("Select[str]", focused)
             self._cycle_select_option(select_widget, direction=1 if event.key == "right" else -1)
             return
 
@@ -550,10 +550,10 @@ class SettingsScreen(Screen[Settings | None]):
 
         # Update the app's settings
         # Access the app's _settings attribute directly since we need to update it
-        self.app._settings = validated  # type: ignore[attr-defined]
+        self.app._settings = validated  # ty: ignore[unresolved-attribute]
 
         # Trigger energy data reload
-        self.app.reload_energy_data()  # type: ignore[attr-defined]
+        self.app.reload_energy_data()  # ty: ignore[unresolved-attribute]
 
         # Dismiss the settings screen
         self.dismiss(None)

--- a/stoei/widgets/settings_screen.py
+++ b/stoei/widgets/settings_screen.py
@@ -10,6 +10,7 @@ from textual.events import Key
 from textual.screen import Screen
 from textual.widgets import Button, Input, Select, Static, Switch
 
+from stoei.keybindings import KeybindMode
 from stoei.logger import get_logger
 from stoei.settings import (
     KEYBIND_MODES,
@@ -19,6 +20,7 @@ from stoei.settings import (
     MIN_JOB_HISTORY_DAYS,
     MIN_LOG_LINES,
     MIN_REFRESH_INTERVAL,
+    LogLevel,
     Settings,
     save_settings,
 )
@@ -423,7 +425,7 @@ class SettingsScreen(Screen[Settings | None]):
             return None
         return theme_value
 
-    def _validate_log_level(self) -> str | None:
+    def _validate_log_level(self) -> LogLevel | None:
         """Validate and return log level selection."""
         log_level_select = self.query_one("#settings-log-level", Select)
         log_level_value = log_level_select.value
@@ -431,7 +433,7 @@ class SettingsScreen(Screen[Settings | None]):
             logger.warning("Invalid log level selection")
             self.app.notify("Please select a valid log level", severity="warning")
             return None
-        return log_level_value
+        return cast("LogLevel", log_level_value)
 
     def _validate_max_lines(self) -> int | None:
         """Validate and return max log lines value."""
@@ -481,7 +483,7 @@ class SettingsScreen(Screen[Settings | None]):
             return None
         return job_history_days
 
-    def _validate_keybind_mode(self) -> str | None:
+    def _validate_keybind_mode(self) -> KeybindMode | None:
         """Validate and return keybind mode selection."""
         keybind_select = self.query_one("#settings-keybind-mode", Select)
         keybind_value = keybind_select.value
@@ -489,7 +491,7 @@ class SettingsScreen(Screen[Settings | None]):
             logger.warning("Invalid keybind mode selection")
             self.app.notify("Please select a valid keybind mode", severity="warning")
             return None
-        return keybind_value
+        return cast("KeybindMode", keybind_value)
 
     def action_jump_keybind(self) -> None:
         """Jump focus to the keybind mode selector."""

--- a/stoei/widgets/tabs.py
+++ b/stoei/widgets/tabs.py
@@ -1,6 +1,6 @@
 """Tab system widget."""
 
-from typing import ClassVar
+from typing import ClassVar, Literal
 
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal
@@ -11,11 +11,14 @@ from stoei.logger import get_logger
 
 logger = get_logger(__name__)
 
+# The top-level tabs of the application.
+TabName = Literal["jobs", "nodes", "users", "priority", "logs"]
+
 
 class TabSwitched(Message):
     """Message sent when a tab is switched."""
 
-    def __init__(self, tab_name: str) -> None:
+    def __init__(self, tab_name: TabName) -> None:
         """Initialize the TabSwitched message.
 
         Args:
@@ -79,7 +82,7 @@ class TabContainer(Container):
     def __init__(self, *args, **kwargs) -> None:
         """Initialize the TabContainer."""
         super().__init__(*args, **kwargs)
-        self._active_tab: str = "jobs"
+        self._active_tab: TabName = "jobs"
         self._tabs: dict[str, Container] = {}
         self._is_compact: bool = False
         self._tab_labels: dict[str, tuple[str, str]] = {
@@ -116,7 +119,7 @@ class TabContainer(Container):
         elif event.button.id == "tab-logs":
             self.switch_tab("logs")
 
-    def switch_tab(self, tab_name: str) -> None:
+    def switch_tab(self, tab_name: TabName) -> None:
         """Switch to a different tab.
 
         Args:
@@ -166,7 +169,7 @@ class TabContainer(Container):
         self.post_message(TabSwitched(tab_name))
 
     @property
-    def active_tab(self) -> str:
+    def active_tab(self) -> TabName:
         """Get the currently active tab name."""
         return self._active_tab
 

--- a/stoei/widgets/user_overview.py
+++ b/stoei/widgets/user_overview.py
@@ -1,7 +1,6 @@
 """User overview tab widget with sub-tabs for running, pending, and energy views."""
 
 from collections import defaultdict
-from dataclasses import dataclass
 from typing import ClassVar, Literal, TypedDict
 
 from textual.app import ComposeResult
@@ -28,26 +27,11 @@ from stoei.slurm.gpu_parser import (
 )
 from stoei.slurm.nodelist import expand_nodelist
 from stoei.slurm.parser import parse_tres_resources
+from stoei.usage_stats import UserEnergyStats, UserPendingStats, UserStats
 from stoei.widgets.filterable_table import ColumnConfig, FilterableDataTable
 from stoei.widgets.screens import EnergyEnableModal
 
 logger = get_logger(__name__)
-
-
-@dataclass
-class UserStats:
-    """User resource usage statistics."""
-
-    username: str
-    job_count: int
-    total_cpus: int
-    total_memory_gb: float
-    total_gpus: int
-    total_nodes: int
-    gpu_types: str = ""
-    node_names: str = ""
-    array_count: int = 0
-    plain_job_count: int = 0
 
 
 class _UserDataDict(TypedDict):
@@ -63,18 +47,6 @@ class _UserDataDict(TypedDict):
     plain_job_count: int
 
 
-@dataclass
-class UserPendingStats:
-    """User pending job resource statistics."""
-
-    username: str
-    pending_job_count: int
-    pending_cpus: int
-    pending_memory_gb: float
-    pending_gpus: int
-    pending_gpu_types: str = ""
-
-
 class _UserPendingDataDict(TypedDict):
     """Internal dictionary structure for aggregating user pending statistics."""
 
@@ -83,17 +55,6 @@ class _UserPendingDataDict(TypedDict):
     pending_memory_gb: float
     pending_gpus: int
     gpu_types: dict[str, int]
-
-
-@dataclass
-class UserEnergyStats:
-    """User energy usage statistics over a historical period."""
-
-    username: str
-    total_energy_wh: float  # Total energy in Watt-hours
-    job_count: int  # Number of completed jobs
-    gpu_hours: float  # Total GPU-hours used
-    cpu_hours: float  # Total CPU-hours used
 
 
 class _UserEnergyDataDict(TypedDict):
@@ -368,7 +329,7 @@ class UserOverviewTab(VerticalScroll):
         """
         if result == "settings":
             # Navigate to settings screen
-            self.app.action_show_settings()  # type: ignore[attr-defined]
+            self.app.action_show_settings()  # ty: ignore[unresolved-attribute]
 
     def update_users(self, users: list[UserStats]) -> None:
         """Update the user data table.

--- a/stoei/widgets/user_overview.py
+++ b/stoei/widgets/user_overview.py
@@ -66,10 +66,14 @@ class _UserEnergyDataDict(TypedDict):
     cpu_hours: float
 
 
+# Type alias for subtab names
+SubtabName = Literal["running", "pending", "energy"]
+
+
 class SubtabSwitched(Message):
     """Message sent when a sub-tab within the user overview is switched."""
 
-    def __init__(self, subtab_name: str) -> None:
+    def __init__(self, subtab_name: SubtabName) -> None:
         """Initialize the SubtabSwitched message.
 
         Args:
@@ -77,10 +81,6 @@ class SubtabSwitched(Message):
         """
         super().__init__()
         self.subtab_name = subtab_name
-
-
-# Type alias for subtab names
-SubtabName = Literal["running", "pending", "energy"]
 
 
 class UserOverviewTab(VerticalScroll):

--- a/tests/integration/test_user_actions.py
+++ b/tests/integration/test_user_actions.py
@@ -95,6 +95,7 @@ def slurm_monitor_factory(monkeypatch: pytest.MonkeyPatch) -> Callable[[], Slurm
 
         app.set_interval = _noop  # type: ignore[assignment]
         app._start_refresh_worker = _noop  # type: ignore[assignment]
+        app._start_running_refresh_worker = _noop  # type: ignore[assignment]
         app._start_initial_load_worker = _noop  # type: ignore[assignment]
         return app
 
@@ -160,22 +161,22 @@ async def test_new_jobs_appear_after_refresh(slurm_monitor_factory: Callable[[],
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
 
-        # Seed the table with initial data (initial load worker is nooped)
-        initial_result = (list(RUNNING_JOBS), list(HISTORY_JOBS), len(HISTORY_JOBS), 0, 0)
-        app._apply_fetch_result("user_jobs", initial_result)
+        # Seed the table with initial data (initial load worker is nooped):
+        # history via the heavy loop, running jobs via the fast loop.
+        app._apply_fetch_result("history", (list(HISTORY_JOBS), len(HISTORY_JOBS), 0, 0))
+        app._apply_running_jobs_result(list(RUNNING_JOBS))
         await pilot.pause()
         await pilot.pause()
 
         jobs_ft = app.query_one("#jobs-filterable-table", FilterableDataTable)
         initial_count = jobs_ft.table.row_count
 
-        # Simulate a refresh that returns the original job + a new one
+        # Simulate a fast-loop refresh that returns the original job + a new one
         new_running: list[tuple[str, ...]] = [
             *RUNNING_JOBS,
             ("102", "eval", "RUNNING", "00:05:00", "1", "node002", "2024-01-15T11:00:00", "2024-01-15T11:00:00"),
         ]
-        result = (new_running, list(HISTORY_JOBS), len(HISTORY_JOBS), 0, 0)
-        app._apply_fetch_result("user_jobs", result)
+        app._apply_running_jobs_result(new_running)
 
         # Let the _UICallback → _update_jobs_table → call_later chain run
         await pilot.pause()
@@ -198,9 +199,10 @@ async def test_completed_jobs_removed_after_refresh(slurm_monitor_factory: Calla
     async with app.run_test(size=(80, 24)) as pilot:
         await pilot.pause()
 
-        # Seed the table with initial data (initial load worker is nooped)
-        initial_result = (list(RUNNING_JOBS), list(HISTORY_JOBS), len(HISTORY_JOBS), 0, 0)
-        app._apply_fetch_result("user_jobs", initial_result)
+        # Seed the table with initial data (initial load worker is nooped):
+        # history via the heavy loop, running jobs via the fast loop.
+        app._apply_fetch_result("history", (list(HISTORY_JOBS), len(HISTORY_JOBS), 0, 0))
+        app._apply_running_jobs_result(list(RUNNING_JOBS))
         await pilot.pause()
         await pilot.pause()
 
@@ -208,7 +210,8 @@ async def test_completed_jobs_removed_after_refresh(slurm_monitor_factory: Calla
         initial_count = jobs_ft.table.row_count
         assert initial_count > 0, "Expected at least one job after initial seed"
 
-        # Simulate a refresh where the running job completed and moved to history
+        # Simulate the running job completing: it drops from squeue (fast loop) and
+        # reappears in the sacct history (heavy loop).
         new_history: list[tuple[str, ...]] = [
             *HISTORY_JOBS,
             (
@@ -224,14 +227,8 @@ async def test_completed_jobs_removed_after_refresh(slurm_monitor_factory: Calla
                 "2024-01-15T10:10:00",
             ),
         ]
-        result: tuple[list[tuple[str, ...]], list[tuple[str, ...]], int, int, int] = (
-            [],  # no running jobs
-            new_history,
-            len(new_history),
-            0,
-            0,
-        )
-        app._apply_fetch_result("user_jobs", result)
+        app._apply_running_jobs_result([])  # no running jobs
+        app._apply_fetch_result("history", (new_history, len(new_history), 0, 0))
 
         await pilot.pause()
         await pilot.pause()

--- a/tests/unit/test_app_refresh_fallback.py
+++ b/tests/unit/test_app_refresh_fallback.py
@@ -155,76 +155,73 @@ class TestErrorNotificationDeduplication:
             patch.object(app, "_post_ui_callback") as mock_call,
         ):
             # First failure
-            results: dict[str, object] = {"user_jobs": (None, None, 0, 0, 0)}
-            app._process_refresh_results(results)
+            app._apply_running_jobs_result(None)
             assert mock_call.call_count == 1
             assert app._error_notified.get("running_jobs") is True
 
             # Second failure - no new notification
             mock_call.reset_mock()
-            app._process_refresh_results(results)
+            app._apply_running_jobs_result(None)
             assert mock_call.call_count == 0
 
     def test_running_jobs_success_clears_error_flag(self) -> None:
         """Successful running jobs fetch clears the error flag."""
         app = SlurmMonitor()
         running_jobs = [("1", "job1", "RUNNING", "1:00", "1", "node1")]
-        history_jobs = [("2", "job2", "COMPLETED", "0:00", "1", "node1")]
 
         with (
             patch.object(app._job_cache, "_build_from_data"),
             patch.object(app, "_post_ui_callback") as mock_call,
         ):
             # First failure
-            results_fail: dict[str, object] = {"user_jobs": (None, None, 0, 0, 0)}
-            app._process_refresh_results(results_fail)
+            app._apply_running_jobs_result(None)
             assert mock_call.call_count == 1
 
             # Success clears flag
-            results_ok: dict[str, object] = {"user_jobs": (running_jobs, history_jobs, 1, 0, 0)}
-            app._process_refresh_results(results_ok)
+            app._apply_running_jobs_result(running_jobs)
             assert app._error_notified.get("running_jobs") is False
 
             # Next failure re-notifies
             mock_call.reset_mock()
-            app._process_refresh_results(results_fail)
+            app._apply_running_jobs_result(None)
             assert mock_call.call_count == 1
 
     def test_independent_tracking_of_running_and_history(self) -> None:
-        """Running jobs and history errors are tracked independently."""
+        """Running jobs and history errors are tracked independently across loops."""
         app = SlurmMonitor()
         running_jobs = [("1", "job1", "RUNNING", "1:00", "1", "node1")]
 
         with (
             patch.object(app._job_cache, "_build_from_data"),
-            patch.object(app, "_post_ui_callback") as mock_call,
+            patch.object(app, "_post_ui_callback"),
         ):
-            # Running OK, history fails - should notify once for history
-            results: dict[str, object] = {"user_jobs": (running_jobs, None, 0, 0, 0)}
-            app._process_refresh_results(results)
-            assert mock_call.call_count == 1
+            # Fast loop: running OK
+            app._apply_running_jobs_result(running_jobs)
+            # Heavy loop: history fails
+            app._apply_fetch_result("history", (None, 0, 0, 0))
+
             assert app._error_notified.get("running_jobs") is False
             assert app._error_notified.get("history_jobs") is True
 
     def test_both_fail_simultaneously(self) -> None:
-        """Both running and history failing shows both notifications once."""
+        """Both running and history failing shows each notification once."""
         app = SlurmMonitor()
 
         with (
             patch.object(app._job_cache, "_build_from_data"),
             patch.object(app, "_post_ui_callback") as mock_call,
         ):
-            # Both fail
-            results: dict[str, object] = {"user_jobs": (None, None, 0, 0, 0)}
-            app._process_refresh_results(results)
-            # Running jobs failed notification
-            assert mock_call.call_count == 1
+            app._apply_running_jobs_result(None)
+            app._apply_fetch_result("history", (None, 0, 0, 0))
             assert app._error_notified.get("running_jobs") is True
+            assert app._error_notified.get("history_jobs") is True
+            both_count = mock_call.call_count
 
-            # Second cycle - no new notifications
+            # Second cycle - no new notifications (table updates aside)
             mock_call.reset_mock()
-            app._process_refresh_results(results)
-            assert mock_call.call_count == 0
+            app._apply_running_jobs_result(None)
+            app._apply_fetch_result("history", (None, 0, 0, 0))
+            assert mock_call.call_count < both_count
 
     def test_manual_refresh_resets_error_flags(self) -> None:
         """Manual refresh clears error flags so user always gets feedback."""
@@ -236,6 +233,7 @@ class TestErrorNotificationDeduplication:
 
         with (
             patch.object(app, "notify"),
+            patch.object(app, "_start_running_refresh_worker"),
             patch.object(app, "_start_refresh_worker"),
         ):
             app.action_refresh()
@@ -245,32 +243,20 @@ class TestErrorNotificationDeduplication:
     def test_history_processed_independently_when_running_fails(self) -> None:
         """Valid history data is still cached when running jobs fail."""
         app = SlurmMonitor()
-        history_jobs = [("2", "job2", "COMPLETED", "0:00", "1", "node1")]
+        history_jobs = [("2", "job2", "COMPLETED", "0", "0:00", "0:0", "node1", "t", "t", "t")]
 
         with (
             patch.object(app._job_cache, "_build_from_data"),
             patch.object(app, "_post_ui_callback"),
         ):
-            results: dict[str, object] = {"user_jobs": (None, history_jobs, 5, 1, 2)}
-            app._process_refresh_results(results)
+            # Fast loop failed (None), but the heavy loop still delivers history
+            app._apply_running_jobs_result(None)
+            app._apply_fetch_result("history", (history_jobs, 5, 1, 2))
 
             # History should be cached even though running jobs failed
             assert app._last_history_jobs == history_jobs
             assert app._last_history_stats == (5, 1, 2)
             assert app._error_notified.get("history_jobs") is False
-
-    def test_user_jobs_not_in_results(self) -> None:
-        """No notification or crash when user_jobs key is missing from results."""
-        app = SlurmMonitor()
-
-        with (
-            patch.object(app._job_cache, "_build_from_data"),
-            patch.object(app, "_post_ui_callback") as mock_call,
-        ):
-            results: dict[str, object] = {}
-            app._process_refresh_results(results)
-            # No notifications when the key is simply missing
-            assert mock_call.call_count == 0
 
 
 class TestApplyFetchResult:
@@ -294,43 +280,46 @@ class TestApplyFetchResult:
         return instance
 
     # ------------------------------------------------------------------
-    # user_jobs — running jobs fail path
+    # history
     # ------------------------------------------------------------------
 
-    def test_user_jobs_running_fail_notifies_and_updates_table(self, app: SlurmMonitor) -> None:
-        """Failing running-jobs fetch notifies once and always schedules table update."""
+    def test_history_success_caches_and_schedules_table_update(self, app: SlurmMonitor) -> None:
+        """A successful history result caches the data and schedules a table update."""
+        app._last_running_jobs = [("1", "job1", "RUNNING", "1:00", "1", "node1", "t", "t")]
+        history_jobs = [("2", "job2", "COMPLETED", "0", "0:00", "0:0", "node1", "t", "t", "t")]
+
+        with (
+            patch.object(app._job_cache, "_build_from_data") as mock_build,
+            patch.object(app, "_post_ui_callback") as mock_call,
+        ):
+            app._apply_fetch_result("history", (history_jobs, 3, 1, 2))
+
+        mock_build.assert_called_once_with(app._last_running_jobs, history_jobs, 3, 1, 2)
+        assert app._last_history_jobs == history_jobs
+        assert app._last_history_stats == (3, 1, 2)
+        assert mock_call.call_count == 1
+
+    def test_history_failure_notifies_once_and_keeps_cached(self, app: SlurmMonitor) -> None:
+        """A failed history fetch (None) notifies once and keeps the cached history."""
+        cached = [("2", "job2", "COMPLETED", "0", "0:00", "0:0", "node1", "t", "t", "t")]
+        app._last_history_jobs = cached
+        app._last_history_stats = (1, 0, 0)
+
         with (
             patch.object(app._job_cache, "_build_from_data"),
             patch.object(app, "_post_ui_callback") as mock_call,
         ):
-            app._apply_fetch_result("user_jobs", (None, None, 0, 0, 0))
-
-            # Error flag must be set
-            assert app._error_notified.get("running_jobs") is True
-            # _post_ui_callback called once: the warning notification lambda
-            # (the table update is also scheduled — two calls total; first is
-            # the notify lambda, second is _update_jobs_table)
-            assert mock_call.call_count == 2
-            # Second positional arg of the last call is _update_jobs_table (lambda)
-            # We just verify it was called — we don't invoke it (needs event loop).
-            assert mock_call.call_count >= 1
-
-    def test_user_jobs_running_fail_second_time_no_extra_notification(self, app: SlurmMonitor) -> None:
-        """Second consecutive running-jobs failure does not emit a second notification."""
-        with (
-            patch.object(app._job_cache, "_build_from_data"),
-            patch.object(app, "_post_ui_callback") as mock_call,
-        ):
-            app._apply_fetch_result("user_jobs", (None, None, 0, 0, 0))
+            app._apply_fetch_result("history", (None, 0, 0, 0))
             first_count = mock_call.call_count
+            assert app._error_notified.get("history_jobs") is True
 
             mock_call.reset_mock()
-            app._apply_fetch_result("user_jobs", (None, None, 0, 0, 0))
-            second_count = mock_call.call_count
+            app._apply_fetch_result("history", (None, 0, 0, 0))
+            # Second consecutive failure does not re-notify (fewer callbacks)
+            assert mock_call.call_count < first_count
 
-            # First run: 2 calls (notify + table update)
-            # Second run: only 1 call (table update, NO notify because flag already set)
-            assert second_count < first_count
+        # Cached history is preserved across failures
+        assert app._last_history_jobs == cached
 
     # ------------------------------------------------------------------
     # nodes
@@ -554,8 +543,8 @@ class TestOnRefreshComplete:
 
         assert app._initial_background_complete is True
 
-    def test_first_cycle_starts_auto_refresh_timer(self, app: SlurmMonitor) -> None:
-        """First cycle calls set_interval to set up the auto-refresh timer."""
+    def test_first_cycle_starts_heavy_refresh_timer(self, app: SlurmMonitor) -> None:
+        """First cycle registers the recurring heavy-refresh timer at the heavy interval."""
         app._initial_background_complete = False
 
         with (
@@ -564,7 +553,7 @@ class TestOnRefreshComplete:
         ):
             app._on_refresh_complete(is_first_cycle=True)
 
-        mock_set_interval.assert_called_once_with(app.refresh_interval, app._start_refresh_worker)
+        mock_set_interval.assert_called_once_with(app.heavy_refresh_interval, app._start_refresh_worker)
 
     def test_first_cycle_starts_auto_refresh(self, app: SlurmMonitor) -> None:
         """First cycle starts the auto-refresh timer."""
@@ -624,10 +613,7 @@ class TestJobInfoCacheInvalidation:
         app._job_info_cache = {"1": ("info1", None, None, None), "2": ("info2", None, None, None)}
 
         with patch.object(app, "_post_ui_callback"):
-            app._apply_fetch_result(
-                "user_jobs",
-                ([self._squeue("1", "RUNNING"), self._squeue("2", "RUNNING")], [], 0, 0, 0),
-            )
+            app._apply_running_jobs_result([self._squeue("1", "RUNNING"), self._squeue("2", "RUNNING")])
 
         assert "1" not in app._job_info_cache  # PENDING -> RUNNING: evicted
         assert "2" in app._job_info_cache  # RUNNING -> RUNNING: kept
@@ -638,10 +624,7 @@ class TestJobInfoCacheInvalidation:
         app._job_info_cache = {"1": ("info1", None, None, None), "2": ("info2", None, None, None)}
 
         with patch.object(app, "_post_ui_callback"):
-            app._apply_fetch_result(
-                "user_jobs",
-                ([self._squeue("1", "RUNNING"), self._squeue("2", "RUNNING")], [], 0, 0, 0),
-            )
+            app._apply_running_jobs_result([self._squeue("1", "RUNNING"), self._squeue("2", "RUNNING")])
 
         assert "1" not in app._job_info_cache  # PENDING -> RUNNING: evicted
         assert "2" in app._job_info_cache  # absent from old snapshot: left untouched
@@ -652,7 +635,7 @@ class TestJobInfoCacheInvalidation:
         app._job_info_cache = {"1": ("info1", None, None, None)}
 
         with patch.object(app, "_post_ui_callback"):
-            app._apply_fetch_result("user_jobs", ([], [], 0, 0, 0))
+            app._apply_running_jobs_result([])
 
         assert "1" not in app._job_info_cache
 
@@ -662,6 +645,109 @@ class TestJobInfoCacheInvalidation:
         app._job_info_cache = {"12345": ("info", None, None, None)}
 
         with patch.object(app, "_post_ui_callback"):
-            app._apply_fetch_result("user_jobs", ([], [], 0, 0, 0))
+            app._apply_running_jobs_result([])
 
         assert "12345" not in app._job_info_cache
+
+
+class TestRunningJobsRefreshDecoupling:
+    """Tests for the fast running-jobs loop being decoupled from the slow history loop.
+
+    The jobs-table "Time" column is driven by ``squeue`` and must refresh on its
+    own fast cadence without waiting for (or being gated by) the slow ``sacct``
+    history fetch. The fast loop rebuilds the table from fresh running jobs plus
+    the *cached* history; the slow loop rebuilds it from the *cached* running jobs
+    plus fresh history.
+    """
+
+    @pytest.fixture(autouse=True)
+    def reset_job_cache(self) -> None:
+        """Reset JobCache singleton before each test."""
+        JobCache.reset()
+
+    @pytest.fixture
+    def app(self) -> SlurmMonitor:
+        """Return a bare SlurmMonitor with widget-tree side-effects stubbed out."""
+        instance = SlurmMonitor()
+        instance._parse_node_infos = MagicMock(return_value=[])  # type: ignore[method-assign]
+        instance._compute_user_overview_cache = MagicMock()  # type: ignore[method-assign]
+        instance._calculate_cluster_stats = MagicMock(return_value=None)  # type: ignore[method-assign]
+        instance._compute_priority_overview_cache = MagicMock()  # type: ignore[method-assign]
+        return instance
+
+    def test_running_refresh_rebuilds_from_cached_history(self, app: SlurmMonitor) -> None:
+        """The fast loop rebuilds the table from fresh running jobs + cached history."""
+        cached_history = [("2", "job2", "COMPLETED", "0", "0:00", "0:0", "node1", "t", "t", "t")]
+        app._last_history_jobs = cached_history
+        app._last_history_stats = (1, 0, 0)
+
+        running_jobs = [("1", "job1", "RUNNING", "1:00", "1", "node1", "t", "t")]
+
+        with (
+            patch.object(app._job_cache, "_build_from_data") as mock_build,
+            patch.object(app, "_post_ui_callback"),
+        ):
+            app._apply_running_jobs_result(running_jobs)
+
+        mock_build.assert_called_once_with(running_jobs, cached_history, 1, 0, 0)
+        assert app._last_running_jobs == running_jobs
+
+    def test_running_refresh_schedules_table_update(self, app: SlurmMonitor) -> None:
+        """The fast loop schedules a jobs-table UI update."""
+        running_jobs = [("1", "job1", "RUNNING", "1:00", "1", "node1", "t", "t")]
+
+        with (
+            patch.object(app._job_cache, "_build_from_data"),
+            patch.object(app, "_update_jobs_table"),
+            patch.object(app, "_post_ui_callback") as mock_call,
+        ):
+            app._apply_running_jobs_result(running_jobs)
+
+        assert mock_call.call_count == 1
+
+    def test_running_refresh_does_not_reset_history_error_flag(self, app: SlurmMonitor) -> None:
+        """The fast loop must not clear the history error flag (no notification spam)."""
+        app._error_notified["history_jobs"] = True
+
+        running_jobs = [("1", "job1", "RUNNING", "1:00", "1", "node1", "t", "t")]
+
+        with (
+            patch.object(app._job_cache, "_build_from_data"),
+            patch.object(app, "_post_ui_callback"),
+        ):
+            app._apply_running_jobs_result(running_jobs)
+
+        assert app._error_notified["history_jobs"] is True
+
+    def test_running_refresh_failure_keeps_old_data_and_notifies_once(self, app: SlurmMonitor) -> None:
+        """A failed running-jobs fetch (None) notifies once and does not rebuild the cache."""
+        with (
+            patch.object(app._job_cache, "_build_from_data") as mock_build,
+            patch.object(app, "_post_ui_callback") as mock_call,
+        ):
+            app._apply_running_jobs_result(None)
+            assert app._error_notified.get("running_jobs") is True
+            assert mock_call.call_count == 1
+
+            mock_call.reset_mock()
+            app._apply_running_jobs_result(None)
+            assert mock_call.call_count == 0
+
+        mock_build.assert_not_called()
+
+    def test_history_refresh_rebuilds_from_cached_running(self, app: SlurmMonitor) -> None:
+        """The slow loop's history result rebuilds the table from cached running jobs + fresh history."""
+        running_jobs = [("1", "job1", "RUNNING", "1:00", "1", "node1", "t", "t")]
+        app._last_running_jobs = running_jobs
+
+        new_history = [("2", "job2", "COMPLETED", "0", "00:10:00", "0:0", "node1", "t", "t", "t")]
+
+        with (
+            patch.object(app._job_cache, "_build_from_data") as mock_build,
+            patch.object(app, "_post_ui_callback"),
+        ):
+            app._apply_fetch_result("history", (new_history, 5, 1, 2))
+
+        mock_build.assert_called_once_with(running_jobs, new_history, 5, 1, 2)
+        assert app._last_history_jobs == new_history
+        assert app._last_history_stats == (5, 1, 2)

--- a/tests/unit/test_app_refresh_fallback.py
+++ b/tests/unit/test_app_refresh_fallback.py
@@ -539,10 +539,8 @@ class TestOnRefreshComplete:
 
     @pytest.fixture
     def app(self) -> SlurmMonitor:
-        """Return a SlurmMonitor instance with a pre-populated job info cache."""
-        instance = SlurmMonitor()
-        instance._job_info_cache["123"] = ("formatted", None, None, None)
-        return instance
+        """Return a bare SlurmMonitor instance."""
+        return SlurmMonitor()
 
     def test_first_cycle_sets_initial_background_complete(self, app: SlurmMonitor) -> None:
         """First cycle sets _initial_background_complete = True."""
@@ -578,13 +576,6 @@ class TestOnRefreshComplete:
         assert app._initial_background_complete is True
         mock_interval.assert_called_once()
 
-    def test_first_cycle_clears_job_info_cache(self, app: SlurmMonitor) -> None:
-        """_on_refresh_complete always clears the job info cache."""
-        with patch.object(app, "set_interval", return_value=MagicMock()):
-            app._on_refresh_complete(is_first_cycle=True)
-
-        assert app._job_info_cache == {}
-
     def test_subsequent_cycle_does_not_call_set_interval(self, app: SlurmMonitor) -> None:
         """Subsequent refresh cycles must not re-register the auto-refresh timer."""
         app._initial_background_complete = True
@@ -598,14 +589,79 @@ class TestOnRefreshComplete:
         mock_set_interval.assert_not_called()
         mock_notify.assert_not_called()
 
-    def test_subsequent_cycle_clears_job_info_cache(self, app: SlurmMonitor) -> None:
-        """Subsequent refresh cycles still clear the job info cache."""
-        app._initial_background_complete = True
 
-        with (
-            patch.object(app, "set_interval"),
-            patch.object(app, "notify"),
-        ):
-            app._on_refresh_complete(is_first_cycle=False)
+class TestJobInfoCacheInvalidation:
+    """Tests for selective modal job-info cache invalidation on state change.
 
-        assert app._job_info_cache == {}
+    The job-detail modal is served from ``_job_info_cache`` (scontrol/sacct
+    output). A refresh must evict only entries whose state changed so the
+    modal re-fetches them, while unchanged jobs keep their cached entry.
+    """
+
+    @pytest.fixture(autouse=True)
+    def reset_job_cache(self) -> None:
+        """Reset JobCache singleton before each test."""
+        JobCache.reset()
+
+    @pytest.fixture
+    def app(self) -> SlurmMonitor:
+        """Return a bare SlurmMonitor with widget-tree side-effects stubbed out."""
+        instance = SlurmMonitor()
+        instance._parse_node_infos = MagicMock(return_value=[])  # type: ignore[method-assign]
+        instance._compute_user_overview_cache = MagicMock()  # type: ignore[method-assign]
+        instance._calculate_cluster_stats = MagicMock(return_value=None)  # type: ignore[method-assign]
+        instance._compute_priority_overview_cache = MagicMock()  # type: ignore[method-assign]
+        return instance
+
+    @staticmethod
+    def _squeue(job_id: str, state: str) -> tuple[str, ...]:
+        """Build an 8-field squeue row tuple for the given job ID and state."""
+        return (job_id, "job", state, "1:00", "1", "node1", "2026-01-01T00:00:00", "2026-01-01T00:00:00")
+
+    def test_changed_state_evicts_entry_unchanged_kept(self, app: SlurmMonitor) -> None:
+        """A job whose state changed is evicted; an unchanged job's entry survives."""
+        app._job_cache._build_from_data([self._squeue("1", "PENDING"), self._squeue("2", "RUNNING")], [], 0, 0, 0)
+        app._job_info_cache = {"1": ("info1", None, None, None), "2": ("info2", None, None, None)}
+
+        with patch.object(app, "_post_ui_callback"):
+            app._apply_fetch_result(
+                "user_jobs",
+                ([self._squeue("1", "RUNNING"), self._squeue("2", "RUNNING")], [], 0, 0, 0),
+            )
+
+        assert "1" not in app._job_info_cache  # PENDING -> RUNNING: evicted
+        assert "2" in app._job_info_cache  # RUNNING -> RUNNING: kept
+
+    def test_new_job_in_same_cycle_not_evicted(self, app: SlurmMonitor) -> None:
+        """A job appearing for the first time this cycle is not evicted; a changed one is."""
+        app._job_cache._build_from_data([self._squeue("1", "PENDING")], [], 0, 0, 0)
+        app._job_info_cache = {"1": ("info1", None, None, None), "2": ("info2", None, None, None)}
+
+        with patch.object(app, "_post_ui_callback"):
+            app._apply_fetch_result(
+                "user_jobs",
+                ([self._squeue("1", "RUNNING"), self._squeue("2", "RUNNING")], [], 0, 0, 0),
+            )
+
+        assert "1" not in app._job_info_cache  # PENDING -> RUNNING: evicted
+        assert "2" in app._job_info_cache  # absent from old snapshot: left untouched
+
+    def test_vanished_job_evicts_entry(self, app: SlurmMonitor) -> None:
+        """A job that disappears from the cache has its modal entry evicted."""
+        app._job_cache._build_from_data([self._squeue("1", "PENDING")], [], 0, 0, 0)
+        app._job_info_cache = {"1": ("info1", None, None, None)}
+
+        with patch.object(app, "_post_ui_callback"):
+            app._apply_fetch_result("user_jobs", ([], [], 0, 0, 0))
+
+        assert "1" not in app._job_info_cache
+
+    def test_array_job_id_normalized_on_eviction(self, app: SlurmMonitor) -> None:
+        """Array job eviction uses the normalized (bracket-stripped) cache key."""
+        app._job_cache._build_from_data([self._squeue("12345_[0-99]", "PENDING")], [], 0, 0, 0)
+        app._job_info_cache = {"12345": ("info", None, None, None)}
+
+        with patch.object(app, "_post_ui_callback"):
+            app._apply_fetch_result("user_jobs", ([], [], 0, 0, 0))
+
+        assert "12345" not in app._job_info_cache


### PR DESCRIPTION
## Summary

- **Sync job detail modal with live job state**: replace the wholesale per-cycle clear of `_job_info_cache` with selective invalidation — only modal entries whose job state changed (or vanished) are evicted, so changed jobs re-fetch on next open while unchanged jobs stay cached for instant display.

- **Decouple the running-jobs refresh from the heavy data loop**: the jobs-table "Time" column is driven by `squeue` but was bundled into a single exclusive refresh worker alongside slow `sacct`/`sshare`/`sprio` calls, so the 5s timer skipped every tick until the slowest command returned and the Time column advanced at the slowest fetch's cadence. The refresh now runs as two loops: a fast running-jobs loop (`squeue` only) that drives the jobs table every `refresh_interval`, and a heavy loop (history, nodes, all-users jobs, wait times, priority) on a slower cadence (`heavy_refresh_interval = 4 × refresh_interval`). A lock serializes the two loops' cache rebuilds; each rebuilds from its own fresh data plus the other loop's last-known snapshot.