### PR TITLE
fix(go): stop finished jobs from showing as frozen RUNNING

### DIFF
--- a/internal/slurm/client.go
+++ b/internal/slurm/client.go
@@ -289,8 +289,9 @@ var terminalJobStates = map[string]bool{
 	"PREEMPTED": true, "REVOKED": true, "SPECIAL_EXIT": true,
 }
 
-// isTerminalState reports whether a JobState string denotes a finished job.
-func isTerminalState(state string) bool {
+// IsTerminalState reports whether a JobState string denotes a finished job. The
+// base state is the first token, so "CANCELLED by 1001" classifies as terminal.
+func IsTerminalState(state string) bool {
 	base, _, _ := strings.Cut(strings.TrimSpace(state), " ")
 	return terminalJobStates[base]
 }
@@ -301,8 +302,7 @@ func isTerminalState(state string) bool {
 // head-node sacct query. The controller retains a finished job only briefly
 // (MinJobAge), so the caller must look it up promptly on completion. found is
 // false — with a nil error — when the controller no longer has the job or it is
-// not yet in a terminal state; the next cached sacct refresh then covers it. It
-// never falls back to sacct.
+// not yet in a terminal state. It never falls back to sacct.
 func (c *Client) CompletedJobRecord(ctx context.Context, jobID string) (HistoryJob, bool, error) {
 	normalized := NormalizeArrayJobID(jobID)
 	if err := validateJobID(normalized); err != nil {
@@ -313,7 +313,7 @@ func (c *Client) CompletedJobRecord(ctx context.Context, jobID string) (HistoryJ
 		return HistoryJob{}, false, err
 	}
 	f := ParseScontrolFields(strings.TrimSpace(string(out)))
-	if f["JobId"] == "" || !isTerminalState(f["JobState"]) {
+	if f["JobId"] == "" || !IsTerminalState(f["JobState"]) {
 		return HistoryJob{}, false, nil
 	}
 	return HistoryJob{

--- a/internal/slurm/controller.go
+++ b/internal/slurm/controller.go
@@ -40,7 +40,7 @@ func ParseControllerJobs(raw string) []ControllerJob {
 			continue
 		}
 		jobs = append(jobs, ControllerJob{
-			ID:        f["JobId"],
+			ID:        controllerJobID(f),
 			User:      userName(f["UserId"]),
 			Name:      f["JobName"],
 			State:     baseState(f["JobState"]),
@@ -57,6 +57,25 @@ func ParseControllerJobs(raw string) []ControllerJob {
 		})
 	}
 	return jobs
+}
+
+// controllerJobID returns the job id keyed to match squeue %i. A dispatched
+// array task is reported by scontrol with a distinct per-task JobId (e.g. 12350)
+// alongside ArrayJobId/ArrayTaskId, but squeue and the completion overlay key it
+// as "<ArrayJobId>_<ArrayTaskId>" (e.g. 12345_3). Using that form keeps the
+// journal/history id aligned so the live running row dedups the journal copy and
+// a completion supersedes it; otherwise the array task lingers as a frozen,
+// duplicate RUNNING row. Only a single numeric ArrayTaskId is rewritten; a
+// pending range or list keeps the raw JobId (it is the array-leader id, not the
+// frozen-RUNNING case).
+func controllerJobID(f map[string]string) string {
+	aj, at := f["ArrayJobId"], f["ArrayTaskId"]
+	if aj != "" && at != "" {
+		if _, err := strconv.Atoi(at); err == nil {
+			return aj + "_" + at
+		}
+	}
+	return f["JobId"]
 }
 
 // userName extracts the login name from a scontrol "UserId=name(uid)" value.

--- a/internal/slurm/journal.go
+++ b/internal/slurm/journal.go
@@ -62,7 +62,7 @@ func (j *jobJournal) upsert(jobs []ControllerJob) error {
 		if job.ID == "" {
 			continue
 		}
-		if existing, ok := recs[job.ID]; ok && isTerminalState(existing.State) {
+		if existing, ok := recs[job.ID]; ok && IsTerminalState(existing.State) {
 			existing.LastSeen = now
 			recs[job.ID] = existing
 			continue

--- a/internal/slurm/journal_test.go
+++ b/internal/slurm/journal_test.go
@@ -20,6 +20,26 @@ func TestParseControllerJobs(t *testing.T) {
 	}
 }
 
+func TestParseControllerJobsArrayTaskID(t *testing.T) {
+	// A dispatched array task: scontrol reports a distinct per-task JobId, but
+	// squeue %i (and the completion overlay) key it as "<ArrayJobId>_<ArrayTaskId>".
+	// ParseControllerJobs must use the squeue-style id so the journal/history row
+	// dedups against the live running row instead of leaving a frozen duplicate.
+	raw := "JobId=12350 ArrayJobId=12345 ArrayTaskId=3 JobName=train\n" +
+		"   UserId=alice(1000) GroupId=alice(1000)\n" +
+		"   JobState=RUNNING Reason=None\n" +
+		"   RunTime=00:10:00 SubmitTime=2024-01-15T10:30:00 StartTime=2024-01-15T10:35:00 EndTime=Unknown\n" +
+		"   Partition=gpu NumNodes=1 NumCPUs=8\n" +
+		"   NodeList=gpu-node-05"
+	jobs := ParseControllerJobs(raw)
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	if jobs[0].ID != "12345_3" {
+		t.Errorf("array task ID = %q, want 12345_3 (squeue-style, not the raw per-task JobId)", jobs[0].ID)
+	}
+}
+
 func TestJournalPersistsAndKeepsTerminalFinal(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "jobs.jsonl")
 	j := newJobJournal(path)

--- a/internal/store/completed_test.go
+++ b/internal/store/completed_test.go
@@ -40,15 +40,48 @@ func TestAddCompletedJobMergesAndSacctAbsorbs(t *testing.T) {
 	g1 := s.NextGen(SectionHistory)
 	s.SetHistory([]slurm.HistoryJob{{ID: "old"}}, slurm.HistoryStats{}, g1, nil)
 
-	s.AddCompletedJob(slurm.HistoryJob{ID: "new", State: "COMPLETED"})
+	s.AddCompletedJob(slurm.HistoryJob{ID: "new", State: "COMPLETED", Elapsed: "overlay"})
 	if len(s.HistoryJobs) != 2 || s.HistoryJobs[0].ID != "new" || s.HistoryJobs[1].ID != "old" {
 		t.Fatalf("history = %+v, want overlay [new] before base [old]", s.HistoryJobs)
 	}
 
-	// A later sacct refresh that now includes "new" must not duplicate it.
+	// A later journal refresh that now carries "new" in a terminal state is
+	// authoritative: the overlay copy is pruned and the base record shown (no dup).
+	// The terminal base record (Elapsed "base") must replace the overlay copy,
+	// which exercises the terminal-prune branch in rebuildHistory.
 	g2 := s.NextGen(SectionHistory)
-	s.SetHistory([]slurm.HistoryJob{{ID: "new"}, {ID: "old"}}, slurm.HistoryStats{}, g2, nil)
+	s.SetHistory([]slurm.HistoryJob{
+		{ID: "new", State: "COMPLETED", Elapsed: "base"},
+		{ID: "old", State: "COMPLETED", Elapsed: "base"},
+	}, slurm.HistoryStats{}, g2, nil)
 	if len(s.HistoryJobs) != 2 {
-		t.Errorf("after sacct absorbs the completion, history len = %d, want 2 (no dup)", len(s.HistoryJobs))
+		t.Fatalf("after the journal absorbs the completion, history len = %d, want 2 (no dup)", len(s.HistoryJobs))
+	}
+	for _, j := range s.HistoryJobs {
+		if j.ID == "new" && j.Elapsed != "base" {
+			t.Errorf("job new Elapsed = %q, want \"base\" (terminal base must prune and replace the overlay copy)", j.Elapsed)
+		}
+	}
+}
+
+// TestAddCompletedJobSupersedesRunningBase covers the journal-era case: the
+// history base (sourced from the scontrol journal) carries a job that was
+// RUNNING when it was snapshotted. When that job finishes, the freshly observed
+// terminal record (overlay) must win over the stale RUNNING base record, so the
+// job flips to COMPLETED instead of staying frozen as RUNNING.
+func TestAddCompletedJobSupersedesRunningBase(t *testing.T) {
+	s := New()
+	g1 := s.NextGen(SectionHistory)
+	// The journal base snapshotted job 123 while it was still running.
+	s.SetHistory([]slurm.HistoryJob{{ID: "123", State: "RUNNING", Elapsed: "1:00:00"}}, slurm.HistoryStats{}, g1, nil)
+
+	// Job 123 finishes; the controller lookup reports the terminal record.
+	s.AddCompletedJob(slurm.HistoryJob{ID: "123", State: "COMPLETED", Elapsed: "1:05:00"})
+
+	if len(s.HistoryJobs) != 1 {
+		t.Fatalf("history = %+v, want a single row for job 123 (no dup)", s.HistoryJobs)
+	}
+	if got := s.HistoryJobs[0].State; got != "COMPLETED" {
+		t.Errorf("job 123 state = %q, want COMPLETED (overlay must win over stale RUNNING base)", got)
 	}
 }

--- a/internal/store/merge.go
+++ b/internal/store/merge.go
@@ -11,13 +11,13 @@ type MergedJob struct {
 	// Name is the job name.
 	Name string
 	// State is the scheduler state (for running jobs from squeue, for completed
-	// jobs from sacct).
+	// jobs from the controller journal).
 	State string
-	// Time is the running/elapsed time: squeue %M for active jobs, sacct Elapsed
-	// for history jobs.
+	// Time is the running/elapsed time: squeue %M for active jobs, the journal's
+	// RunTime for history jobs.
 	Time string
 	// Nodes is the node count for active jobs; it is always empty for history jobs
-	// because sacct's history format does not carry it.
+	// because the journal history view does not carry it.
 	Nodes string
 	// NodeList is the allocated node list.
 	NodeList string
@@ -26,19 +26,19 @@ type MergedJob struct {
 
 	// SubmitTime, StartTime, and EndTime are the raw SLURM timestamps used to
 	// render the compact Timeline cell. Active jobs (from squeue) carry submit and
-	// start but no end; history jobs (from sacct) carry all three.
+	// start but no end; history jobs (from the journal) carry all three.
 	SubmitTime string
 	StartTime  string
 	EndTime    string
-	// Restarts is the requeue count, parsed from sacct's Restart field for history
-	// jobs (active jobs report 0).
+	// Restarts is the requeue count, parsed from the journal's Restart field for
+	// history jobs (active jobs report 0).
 	Restarts int
 }
 
 // MergedJobs returns the unified running-plus-history job list for the Jobs tab.
 // The current user's running/pending jobs come first, tracked in a running-id
 // set; then each history job whose JobID is not already running is appended
-// (dedup) with Nodes left empty and State/Time taken from sacct. This is pure (no
+// (dedup) with Nodes left empty and State/Time taken from the journal. This is pure (no
 // IO) and reads only the already-fetched RunningJobs and HistoryJobs, so it is
 // safe to call from Refresh on every tick and unit-testable in isolation.
 func (s *Store) MergedJobs() []MergedJob {
@@ -62,7 +62,7 @@ func (s *Store) MergedJobs() []MergedJob {
 	}
 
 	// History jobs, skipping any already present as a running job. Nodes is empty
-	// because sacct's history format omits it.
+	// because the journal history view omits it.
 	for _, job := range s.HistoryJobs {
 		if _, running := runningIDs[job.ID]; running {
 			continue

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -102,14 +102,14 @@ type Store struct {
 	RunningJobsMeta Meta
 
 	// HistoryJobs is the public history view: the session-completion overlay
-	// followed by the sacct base, rebuilt whenever either changes. Readers use it
-	// directly; historyBase and completed are the inputs rebuildHistory merges.
+	// followed by the journal base, rebuilt whenever either changes. Readers use
+	// it directly; historyBase and completed are the inputs rebuildHistory merges.
 	HistoryJobs  []slurm.HistoryJob
 	HistoryStats slurm.HistoryStats
 	HistoryMeta  Meta
-	// historyBase is the most recent sacct history result; completed holds jobs
-	// observed finishing this session (from scontrol), kept apart so the overlay
-	// survives a sacct refresh until that refresh includes the job.
+	// historyBase is the most recent controller-journal history result; completed
+	// holds jobs observed finishing this session (from scontrol), kept apart so the
+	// overlay survives a journal refresh until that refresh includes the job.
 	historyBase []slurm.HistoryJob
 	completed   []slurm.HistoryJob
 
@@ -289,9 +289,9 @@ func (s *Store) SetRunningJobs(data []slurm.RunningJob, gen uint64, err error) [
 }
 
 // SetHistory applies a job-history fetch result, dropping stale generations. The
-// sacct result is the history base; the session-observed completions overlay is
+// journal result is the history base; the session-observed completions overlay is
 // re-applied on top (rebuildHistory) so a job that finished mid-session stays
-// visible until a sacct refresh absorbs it.
+// visible until a journal refresh absorbs it.
 func (s *Store) SetHistory(jobs []slurm.HistoryJob, stats slurm.HistoryStats, gen uint64, err error) {
 	if s.stale(SectionHistory, gen) {
 		return
@@ -305,9 +305,9 @@ func (s *Store) SetHistory(jobs []slurm.HistoryJob, stats slurm.HistoryStats, ge
 }
 
 // AddCompletedJob records a job observed finishing this session (sourced from
-// scontrol, not sacct) so it appears in the history view immediately. The newest
-// record wins for a duplicate ID; entries the sacct base already covers are
-// dropped on the next rebuild.
+// scontrol) so it appears in the history view immediately. The newest record wins
+// for a duplicate ID; entries the journal base already covers in a terminal state
+// are dropped on the next rebuild.
 func (s *Store) AddCompletedJob(job slurm.HistoryJob) {
 	overlay := make([]slurm.HistoryJob, 0, len(s.completed)+1)
 	overlay = append(overlay, job) // newest first
@@ -321,23 +321,37 @@ func (s *Store) AddCompletedJob(job slurm.HistoryJob) {
 }
 
 // rebuildHistory recomputes the public HistoryJobs as the session-completion
-// overlay followed by the sacct base, dropping overlay entries the base already
-// carries (the sacct record is authoritative once it lands).
+// overlay followed by the journal base. The base is authoritative only for jobs
+// it records in a terminal state: it also snapshots running/pending jobs, so an
+// overlay entry (a freshly observed completion) supersedes a stale non-terminal
+// base record for the same id. Without this, a job that was running when stoei
+// started stays frozen as RUNNING after it finishes, because the base's stale
+// RUNNING snapshot would shadow the overlay's terminal record.
 func (s *Store) rebuildHistory() {
-	baseIDs := make(map[string]struct{}, len(s.historyBase))
+	terminalBase := make(map[string]bool, len(s.historyBase))
 	for _, j := range s.historyBase {
-		baseIDs[j.ID] = struct{}{}
+		if slurm.IsTerminalState(j.State) {
+			terminalBase[j.ID] = true
+		}
 	}
 	kept := make([]slurm.HistoryJob, 0, len(s.completed))
+	overlayIDs := make(map[string]struct{}, len(s.completed))
 	for _, j := range s.completed {
-		if _, ok := baseIDs[j.ID]; !ok {
-			kept = append(kept, j)
+		if terminalBase[j.ID] {
+			continue // the base holds the final record; drop the overlay copy.
 		}
+		kept = append(kept, j)
+		overlayIDs[j.ID] = struct{}{}
 	}
 	s.completed = kept
 	merged := make([]slurm.HistoryJob, 0, len(kept)+len(s.historyBase))
 	merged = append(merged, kept...)
-	merged = append(merged, s.historyBase...)
+	for _, j := range s.historyBase {
+		if _, ok := overlayIDs[j.ID]; ok {
+			continue // superseded by a fresher overlay completion.
+		}
+		merged = append(merged, j)
+	}
 	s.HistoryJobs = merged
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -241,14 +241,15 @@ func (a *App) dispatchRunning() tea.Cmd {
 
 // maxCompletionLookups caps how many just-finished jobs are looked up via
 // scontrol after a single running-jobs refresh, bounding the burst on the
-// controller when a large array drains at once. Any beyond the cap are picked up
-// by the next cached sacct refresh.
+// controller when a large array drains at once. Any beyond the cap are not
+// auto-recovered (history has no ticker); a manual refresh re-reads the journal
+// while the job is still retained by the controller.
 const maxCompletionLookups = 64
 
 // fetchCompletions returns a batched Cmd that asks the controller for the final
 // record of each just-vanished job ID, so completions observed mid-session reach
 // the history view without a sacct query. It returns nil when nothing vanished.
-// ponytail: caps the burst at maxCompletionLookups; the daily sacct covers the rest.
+// ponytail: caps the burst at maxCompletionLookups; a manual refresh re-reads the rest.
 func (a *App) fetchCompletions(ids []string) tea.Cmd {
 	if len(ids) == 0 {
 		return nil

--- a/internal/ui/fetch.go
+++ b/internal/ui/fetch.go
@@ -128,10 +128,10 @@ func fetchRunningJobs(client store.SlurmClient, gen uint64) tea.Cmd {
 	}
 }
 
-// fetchCompletedJob returns a Cmd that asks the controller (scontrol, not sacct)
-// for the final record of a job that just left the running queue, reporting it as
-// a completedJobMsg. A lookup error or a non-terminal/expired job yields found
-// false and is silently dropped — the cached sacct refresh covers it.
+// fetchCompletedJob returns a Cmd that asks the controller (scontrol) for the
+// final record of a job that just left the running queue, reporting it as a
+// completedJobMsg. A lookup error or a non-terminal/expired job yields found
+// false and is silently dropped.
 func fetchCompletedJob(client store.SlurmClient, id string) tea.Cmd {
 	return func() tea.Msg {
 		var found bool


### PR DESCRIPTION
Running jobs that finish mid-session were stuck displaying RUNNING instead of flipping to their terminal state. Two causes, both regressions from the sacct→scontrol-journal switch (3fe0e64):

- `Store.rebuildHistory` dropped a session-completion overlay whenever the journal base carried that job id — even when the base record was a stale non-terminal snapshot (the journal base now includes jobs that were RUNNING at startup). The base is now authoritative only for ids it records in a terminal state; a freshly observed completion supersedes a stale base row.
- Array tasks were keyed by scontrol's per-task `JobId` (e.g. `12350`) while squeue and the completion overlay use `<ArrayJobId>_<ArrayTaskId>` (e.g. `12345_3`), so the journal row never deduped against the live running row and lingered as a frozen duplicate. `ParseControllerJobs` now synthesizes the squeue-style id for dispatched array tasks.

Adds regression tests for both paths and corrects stale `sacct` comments left over from the journal switch.