### PR TITLE
fix(go): show ended jobs as UNKNOWN instead of frozen RUNNING

### DIFF
--- a/cmd/stoei/main.go
+++ b/cmd/stoei/main.go
@@ -54,7 +54,7 @@ func main() {
 
 	// Wire the one-way dependency chain: a Runner shells out to Slurm, the Client
 	// builds/parses commands, the Store holds the data, and the root model renders
-	// it. Job history and energy come from the controller ("scontrol show jobs")
+	// it. Job history comes from the controller ("scontrol show jobs")
 	// accumulated into a persistent on-disk journal — never slurmdbd/sacct —
 	// so the head node is not queried at all; squeue, scontrol, and the rest run
 	// live. The alt-screen is a View field in Bubble Tea v2, so NewProgram takes

--- a/internal/slurm/arrayjob.go
+++ b/internal/slurm/arrayjob.go
@@ -16,8 +16,8 @@ var (
 	arrayRange = regexp.MustCompile(`^(\d+)-(\d+)$`)
 )
 
-// NormalizeArrayJobID strips bracket-based array range notation that scontrol and
-// sacct cannot accept, while leaving single array task IDs intact. For example
+// NormalizeArrayJobID strips bracket-based array range notation that scontrol
+// cannot accept, while leaving single array task IDs intact. For example
 // "12345_[0-99]" becomes "12345" but "12345_5" is unchanged.
 func NormalizeArrayJobID(jobID string) string {
 	if jobID == "" {

--- a/internal/slurm/runner.go
+++ b/internal/slurm/runner.go
@@ -66,7 +66,7 @@ func hasHardFailureSignal(stderr string) bool {
 
 // ExecRunner is the production Runner. It shells out with exec.CommandContext so
 // that cancelling the context kills the underlying process (for example an
-// orphaned sacct).
+// orphaned squeue).
 type ExecRunner struct{}
 
 // Run executes the command and returns its stdout. It captures stderr separately

--- a/internal/slurm/types.go
+++ b/internal/slurm/types.go
@@ -57,9 +57,9 @@ type RunningJob struct {
 	Raw        []string
 }
 
-// HistoryJob is one job from the sacct history query. It mirrors the ten-column
-// sacct format "JobID,JobName,State,Restart,Elapsed,ExitCode,NodeList,Submit,
-// Start,End". Raw holds every pipe-separated field of the row.
+// HistoryJob is one job from the controller journal (scontrol show jobs). It
+// mirrors the ten-column layout "JobID,JobName,State,Restart,Elapsed,ExitCode,
+// NodeList,Submit,Start,End". Raw holds every pipe-separated field of the row.
 type HistoryJob struct {
 	ID       string
 	Name     string

--- a/internal/store/merge.go
+++ b/internal/store/merge.go
@@ -1,5 +1,14 @@
 package store
 
+import "github.com/pjhartout/stoei/internal/slurm"
+
+// endedHistoryState is the state shown for a history job the journal still
+// records as non-terminal but that is no longer in the live queue: its
+// completion was never observed (it aged out of the controller, overflowed the
+// completion-lookup burst cap, or was running when a prior session ended). Such a
+// row would otherwise display a frozen RUNNING. It maps to the neutral color role.
+const endedHistoryState = "UNKNOWN"
+
 // MergedJob is one row of the Jobs tab's unified job list: the current user's
 // running/pending jobs followed by their completed/failed history jobs. It is the
 // display shape the Jobs tab renders (JobID, Name, State, Time, Nodes, NodeList,
@@ -62,15 +71,22 @@ func (s *Store) MergedJobs() []MergedJob {
 	}
 
 	// History jobs, skipping any already present as a running job. Nodes is empty
-	// because the journal history view omits it.
+	// because the journal history view omits it. Once squeue has loaded, a history
+	// job the journal still marks non-terminal but that is absent from the live
+	// queue has necessarily ended (a genuinely running/pending job is in squeue and
+	// was deduped above), so its stale RUNNING is shown as ended rather than frozen.
 	for _, job := range s.HistoryJobs {
 		if _, running := runningIDs[job.ID]; running {
 			continue
 		}
+		state := job.State
+		if s.runningLoaded && !slurm.IsTerminalState(state) {
+			state = endedHistoryState
+		}
 		merged = append(merged, MergedJob{
 			ID:         job.ID,
 			Name:       job.Name,
-			State:      job.State,
+			State:      state,
 			Time:       job.Elapsed,
 			Nodes:      "",
 			NodeList:   job.NodeList,

--- a/internal/store/merge_test.go
+++ b/internal/store/merge_test.go
@@ -71,3 +71,50 @@ func TestMergedJobsEmpty(t *testing.T) {
 		t.Errorf("MergedJobs on empty store = %+v, want empty", got)
 	}
 }
+
+// TestMergedJobsRelabelsStaleRunningHistory covers a history job the journal
+// still records as RUNNING but that has left the live queue (its completion was
+// never observed). Once squeue has loaded, such a row is relabeled rather than
+// shown as a frozen RUNNING; a genuinely running job stays live.
+func TestMergedJobsRelabelsStaleRunningHistory(t *testing.T) {
+	s := New()
+	// squeue loaded successfully and still shows A running.
+	g := s.NextGen(SectionRunningJobs)
+	s.SetRunningJobs([]slurm.RunningJob{{ID: "A", State: "RUNNING", Time: "1:00"}}, g, nil)
+	// The journal records A (still running) and B (RUNNING but gone from the queue).
+	s.HistoryJobs = []slurm.HistoryJob{
+		{ID: "A", State: "RUNNING"},
+		{ID: "B", State: "RUNNING"},
+	}
+
+	byID := map[string]MergedJob{}
+	for _, j := range s.MergedJobs() {
+		byID[j.ID] = j
+	}
+
+	if a := byID["A"]; a.State != "RUNNING" || !a.Active {
+		t.Errorf("A = %+v, want live RUNNING (Active)", a)
+	}
+	b, ok := byID["B"]
+	if !ok {
+		t.Fatal("B missing from merged jobs")
+	}
+	if b.State != "UNKNOWN" {
+		t.Errorf("B state = %q, want UNKNOWN (stale RUNNING relabeled)", b.State)
+	}
+	if b.Active {
+		t.Error("B active = true, want false (history row)")
+	}
+}
+
+// TestMergedJobsKeepsHistoryRunningBeforeSqueueLoads guards the relabel: with no
+// successful running-jobs fetch yet there is no trustworthy squeue snapshot, so a
+// non-terminal history row must be shown verbatim, not relabeled.
+func TestMergedJobsKeepsHistoryRunningBeforeSqueueLoads(t *testing.T) {
+	s := New()
+	s.HistoryJobs = []slurm.HistoryJob{{ID: "B", State: "RUNNING"}}
+	got := s.MergedJobs()
+	if len(got) != 1 || got[0].State != "RUNNING" {
+		t.Errorf("before squeue loads, history state must be left as-is; got %+v", got)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -100,6 +100,10 @@ type Store struct {
 
 	RunningJobs     []slurm.RunningJob
 	RunningJobsMeta Meta
+	// runningLoaded becomes true after the first successful running-jobs fetch and
+	// stays true. Until then MergedJobs has no trustworthy squeue snapshot to tell a
+	// stale history RUNNING row from a live one, so it leaves history states as-is.
+	runningLoaded bool
 
 	// HistoryJobs is the public history view: the session-completion overlay
 	// followed by the journal base, rebuilt whenever either changes. Readers use
@@ -283,6 +287,7 @@ func (s *Store) SetRunningJobs(data []slurm.RunningJob, gen uint64, err error) [
 			}
 		}
 		s.RunningJobs = data
+		s.runningLoaded = true
 	}
 	s.applyMeta(&s.RunningJobsMeta, err)
 	return vanished

--- a/internal/ui/modals/job_detail.go
+++ b/internal/ui/modals/job_detail.go
@@ -37,7 +37,7 @@ type jobDetailLoadedMsg struct {
 
 // JobDetail is the scrollable job-detail modal opened by Enter on a Jobs row or
 // by the "i" job-id prompt. It fetches client.JobDetail in a Cmd (non-blocking,
-// spinner while loading), renders the scontrol/sacct fields by category, and
+// spinner while loading), renders the scontrol fields by category, and
 // offers o/e to open the job's stdout/stderr in the log viewer. The cache and the
 // live job state are supplied by the root so the modal stays a pure view of one
 // job.

--- a/internal/ui/modals/log_viewer.go
+++ b/internal/ui/modals/log_viewer.go
@@ -397,7 +397,7 @@ func (v *LogViewer) openInEditor() tea.Cmd {
 		return toast("No editor found (set $EDITOR)")
 	}
 	// #nosec G204 -- editor comes from $EDITOR/a fixed fallback list, path is a
-	// validated log path from scontrol/sacct.
+	// validated log path from scontrol.
 	cmd := exec.Command(editor, v.path)
 	return tea.ExecProcess(cmd, func(err error) tea.Msg {
 		return editorDoneMsg{err: err}


### PR DESCRIPTION
Follow-ups to the stuck-running-jobs fix (v0.7.3).

- A job the journal still records as non-terminal but that has left the live queue (completion never observed: aged out of the controller, past the completion-lookup burst cap, or running when a prior session ended) surfaced as a frozen `RUNNING` history row. `MergedJobs` now relabels it to `UNKNOWN` once squeue has loaded — a genuinely running/pending job is in squeue and deduped to the live row first, so only stale rows are relabeled. Guarded on a `runningLoaded` flag so nothing is relabeled before the first successful squeue (no false "ended" while squeue is down).
- Sweeps the remaining stale `sacct` references in comments left over from the controller-journal switch (history/array-id/job-detail/log-path docs; drops the removed "energy" mention). Correct "we never query sacct" statements were left intact.

Adds `MergedJobs` relabel + guard tests.