### PR TITLE
perf(go): reduce Slurm controller polling load

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,8 +16,10 @@ const (
 	// seconds.
 	MinRefreshInterval = 1.0
 	MaxRefreshInterval = 300.0
-	// DefaultRefreshInterval is the default fast-tier refresh in seconds.
-	DefaultRefreshInterval = 5.0
+	// DefaultRefreshInterval is the default fast-tier refresh in seconds. It is
+	// deliberately conservative to keep load off the Slurm controller; the slow
+	// tier follows at 4x (40s).
+	DefaultRefreshInterval = 10.0
 
 	// MinJobHistoryDays and MaxJobHistoryDays bound the history window in days.
 	MinJobHistoryDays = 1

--- a/internal/config/default.yaml
+++ b/internal/config/default.yaml
@@ -1,6 +1,6 @@
 # Default stoei configuration. Values out of range are clamped to these on load.
 theme: nord
-refresh_interval: 5
+refresh_interval: 10
 job_history_days: 7
 log_viewer_lines: 10000
 keybind_mode: vim

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -105,6 +105,11 @@ type App struct {
 	// spinnerActive is true while the loading-spinner animation tick is in flight,
 	// so it is started at most once and stopped when nothing is loading.
 	spinnerActive bool
+	// blurred is true while the terminal reports it has lost focus. Both tick tiers
+	// keep re-arming but skip dispatching Slurm fetches while blurred, so a
+	// backgrounded session stops polling the controller; regaining focus triggers an
+	// immediate refresh. Terminals that do not report focus never set it.
+	blurred bool
 
 	// unavailable holds the Slurm-availability error; non-nil renders the
 	// full-screen unavailable screen.
@@ -239,23 +244,26 @@ func (a *App) dispatchRunning() tea.Cmd {
 	return fetchRunningJobs(a.client, gen)
 }
 
-// maxCompletionLookups caps how many just-finished jobs are looked up via
-// scontrol after a single running-jobs refresh, bounding the burst on the
-// controller when a large array drains at once. Any beyond the cap are not
-// auto-recovered (history has no ticker); a manual refresh re-reads the journal
-// while the job is still retained by the controller.
-const maxCompletionLookups = 64
+// completionBulkThreshold is the just-vanished job count above which
+// fetchCompletions switches from one "scontrol show jobid" per id to a single
+// bulk history refresh. A draining array can vanish dozens of jobs in one tick;
+// past this threshold the bulk path is both lighter and complete.
+const completionBulkThreshold = 8
 
-// fetchCompletions returns a batched Cmd that asks the controller for the final
-// record of each just-vanished job ID, so completions observed mid-session reach
-// the history view without a sacct query. It returns nil when nothing vanished.
-// ponytail: caps the burst at maxCompletionLookups; a manual refresh re-reads the rest.
+// fetchCompletions returns a Cmd that records the final state of just-vanished
+// jobs in history, so completions observed mid-session reach the history view.
+// For a small batch it asks the controller for each job's record directly; once
+// the batch exceeds completionBulkThreshold (a draining array) it instead runs
+// one bulk "scontrol show jobs" history refresh (throttled at the client), which
+// captures every retained job in a single controller call rather than dozens —
+// and, unlike the per-id path, drops none of them. Returns nil when nothing
+// vanished.
 func (a *App) fetchCompletions(ids []string) tea.Cmd {
 	if len(ids) == 0 {
 		return nil
 	}
-	if len(ids) > maxCompletionLookups {
-		ids = ids[:maxCompletionLookups]
+	if len(ids) > completionBulkThreshold {
+		return a.dispatchHistory()
 	}
 	cmds := make([]tea.Cmd, len(ids))
 	for i, id := range ids {
@@ -331,6 +339,14 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyPressMsg:
 		return a.handleKey(msg)
+
+	case tea.FocusMsg:
+		a.blurred = false
+		return a, a.manualRefresh() // resume with fresh data on return
+
+	case tea.BlurMsg:
+		a.blurred = true
+		return a, nil
 
 	case availabilityMsg:
 		a.availChecked = true
@@ -625,28 +641,34 @@ func tabForKey(msg tea.KeyPressMsg) (tabIndex, bool) {
 	return 0, false
 }
 
-// manualRefresh re-dispatches the minimal-critical and heavy waves, bumping every
-// generation so superseded in-flight results are dropped (I4). The caller owns any
-// user-visible feedback (the 'r' key pushes a toast), since re-fetching alone is
-// not visible while data is already on screen.
+// manualRefresh re-dispatches the running and heavy waves, bumping their
+// generations so superseded in-flight results are dropped (I4). Each wave is
+// skipped while it is already in flight: re-dispatching the heavy wave mid-flight
+// would reset heavyPending under the outstanding fetches and clear the guard
+// early, letting the next slow tick pile on a third wave. History refreshes from
+// the controller journal (throttled at the client), so it is always re-run
+// without ever touching slurmdbd. The caller owns user-visible feedback (the 'r'
+// key pushes a toast), since re-fetching alone is not visible while data is on
+// screen.
 func (a *App) manualRefresh() tea.Cmd {
 	a.frame.dirty = true
-	// Re-dispatch every wave. History refreshes from the controller journal
-	// (throttled), so a manual refresh re-runs the live fetches without ever
-	// touching slurmdbd.
-	return tea.Batch(
-		a.dispatchRunning(),
-		a.dispatchHistory(),
-		a.dispatchHeavy(),
-		a.ensureSpinner(),
-	)
+	cmds := []tea.Cmd{a.dispatchHistory()}
+	if !a.runningInFlight {
+		cmds = append(cmds, a.dispatchRunning())
+	}
+	if !a.heavyInFlight {
+		cmds = append(cmds, a.dispatchHeavy())
+	}
+	cmds = append(cmds, a.ensureSpinner())
+	return tea.Batch(cmds...)
 }
 
-// handleFastTick dispatches a running-jobs refresh when none is in flight and
-// always re-arms exactly the fast tier (I2).
+// handleFastTick dispatches a running-jobs refresh when none is in flight and the
+// terminal is focused, and always re-arms exactly the fast tier (I2) so polling
+// resumes the instant focus returns.
 func (a App) handleFastTick() (tea.Model, tea.Cmd) {
 	cmds := []tea.Cmd{fastTick(a.intervals.Fast)}
-	if !a.runningInFlight {
+	if !a.blurred && !a.runningInFlight {
 		cmds = append(cmds, a.dispatchRunning())
 	}
 	// Auto-expire transient toasts each cycle so they don't linger indefinitely.
@@ -659,11 +681,11 @@ func (a App) handleFastTick() (tea.Model, tea.Cmd) {
 	return a, tea.Batch(cmds...)
 }
 
-// handleSlowTick dispatches the heavy batch when none is in flight and always
-// re-arms exactly the slow tier (I2).
+// handleSlowTick dispatches the heavy batch when none is in flight and the
+// terminal is focused, and always re-arms exactly the slow tier (I2).
 func (a App) handleSlowTick() (tea.Model, tea.Cmd) {
 	cmds := []tea.Cmd{slowTick(a.intervals.Slow)}
-	if !a.heavyInFlight {
+	if !a.blurred && !a.heavyInFlight {
 		cmds = append(cmds, a.dispatchHeavy())
 	}
 	cmds = append(cmds, a.ensureSpinner())
@@ -952,6 +974,7 @@ func (a App) View() tea.View {
 
 	v := tea.NewView(content)
 	v.AltScreen = true
+	v.ReportFocus = true // drive the focus/blur backoff (handleFastTick/handleSlowTick)
 	return v
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -94,14 +94,10 @@ type App struct {
 	detailCache *modals.JobDetailCache
 
 	// runningInFlight guards the fast tier: while a running-jobs fetch is
-	// outstanding a fast tick skips dispatching another (but still re-arms).
+	// outstanding a fast tick skips dispatching another (but still re-arms). The
+	// heavy (slow-tier) fetches are instead guarded per section by their
+	// StateLoading flag, so visibility-gated and tick-driven dispatches never stack.
 	runningInFlight bool
-	// heavyInFlight guards the slow tier the same way for the heavy batch. It is
-	// derived from heavyPending so it clears only once all heavy fetches return,
-	// not when whichever finishes first does.
-	heavyInFlight bool
-	// heavyPending counts the outstanding heavy-wave fetches.
-	heavyPending int
 	// spinnerActive is true while the loading-spinner animation tick is in flight,
 	// so it is started at most once and stopped when nothing is loading.
 	spinnerActive bool
@@ -223,7 +219,7 @@ func (a App) Init() tea.Cmd {
 		a.dispatchRunning(),
 		a.dispatchHistory(),
 	)
-	heavy := a.dispatchHeavy()
+	heavy := a.dispatchHeavyVisible()
 
 	return tea.Batch(
 		tea.RequestBackgroundColor,
@@ -280,42 +276,55 @@ func (a *App) dispatchHistory() tea.Cmd {
 	return fetchHistory(a.client, gen, a.cfg.JobHistoryDays)
 }
 
-// dispatchHeavy bumps every heavy section's generation, marks each loading, sets
-// the in-flight guard, and returns a batched Cmd for the whole wave.
-func (a *App) dispatchHeavy() tea.Cmd {
-	a.heavyInFlight = true
-	a.heavyPending = heavyFetchCount
-
-	gNodes := a.store.NextGen(store.SectionNodes)
-	a.store.SetLoading(store.SectionNodes, gNodes)
-	gAll := a.store.NextGen(store.SectionAllUsersJobs)
-	a.store.SetLoading(store.SectionAllUsersJobs, gAll)
-	gFair := a.store.NextGen(store.SectionFairShare)
-	a.store.SetLoading(store.SectionFairShare, gFair)
-	gPend := a.store.NextGen(store.SectionPendingPrio)
-	a.store.SetLoading(store.SectionPendingPrio, gPend)
-
-	return tea.Batch(
-		fetchNodes(a.client, gNodes),
-		fetchAllUsersJobs(a.client, gAll),
-		fetchFairShare(a.client, gFair),
-		fetchPendingPrio(a.client, gPend),
-	)
+// dispatchHeavyVisible dispatches the heavy fetches whose data the UI can
+// currently surface, leaving the rest unpolled to keep load off the controller.
+// Nodes and all-users jobs are always refreshed: they feed the cluster sidebar,
+// the always-available 'L' cluster-load modal, the Jobs My-Usage banner, and the
+// Users tab, so a consumer is reachable from any tab. Fair-share and
+// pending-priority are shown only on the Priority tab and the user/account detail
+// modals (reachable from the Priority and Users tabs), so they are polled only
+// while one of those tabs is active. Each fetch is guarded by its section's
+// StateLoading flag (dispatchSection), so a slow tick and a tab-switch fetch never
+// stack a duplicate, and generation tags drop any superseded result.
+func (a *App) dispatchHeavyVisible() tea.Cmd {
+	cmds := []tea.Cmd{
+		a.dispatchSection(store.SectionNodes),
+		a.dispatchSection(store.SectionAllUsersJobs),
+	}
+	if a.tabNeedsPriorityData(a.active) {
+		cmds = append(cmds, a.dispatchSection(store.SectionFairShare), a.dispatchSection(store.SectionPendingPrio))
+	}
+	return tea.Batch(cmds...)
 }
 
-// heavyFetchCount is the number of fetches dispatchHeavy batches; the slow-tier
-// in-flight guard clears only after all of them return (see heavyDone).
-const heavyFetchCount = 4
+// tabNeedsPriorityData reports whether tab t renders fair-share / pending-priority
+// data: the Priority tab directly, and the Users tab through the user/account
+// detail modal.
+func (a *App) tabNeedsPriorityData(t tabIndex) bool {
+	return t == tabPriority || t == tabUsers
+}
 
-// heavyDone records that one heavy-wave fetch returned, clearing heavyInFlight
-// only once all of them have. The guard must not be cleared by whichever fetch
-// finishes first, or a slow tick would re-dispatch the whole wave while the
-// others are still running.
-func (a *App) heavyDone() {
-	if a.heavyPending > 0 {
-		a.heavyPending--
+// dispatchSection bumps a heavy section's generation, marks it loading, and
+// returns its fetch Cmd — unless it is already loading, in which case it returns
+// nil so a concurrent dispatch is not stacked on top.
+func (a *App) dispatchSection(section store.Section) tea.Cmd {
+	if a.store.State(section) == store.StateLoading {
+		return nil
 	}
-	a.heavyInFlight = a.heavyPending > 0
+	gen := a.store.NextGen(section)
+	a.store.SetLoading(section, gen)
+	switch section {
+	case store.SectionNodes:
+		return fetchNodes(a.client, gen)
+	case store.SectionAllUsersJobs:
+		return fetchAllUsersJobs(a.client, gen)
+	case store.SectionFairShare:
+		return fetchFairShare(a.client, gen)
+	case store.SectionPendingPrio:
+		return fetchPendingPrio(a.client, gen)
+	default:
+		return nil
+	}
 }
 
 // Update is the heart of the model: it wires window-size fanout, background
@@ -374,9 +383,9 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 // handleDataMsg applies an async fetch result to the store and refreshes the
-// affected views, returning handled=false for non-data messages. The six
-// heavy-wave results call heavyDone so the slow-tier guard clears only once all
-// of them return, not when whichever finishes first does.
+// affected views, returning handled=false for non-data messages. Each heavy-wave
+// result clears its own section's loading flag through the store setter, so the
+// per-section dispatch guard releases independently.
 func (a App) handleDataMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 	switch msg := msg.(type) {
 	case runningJobsMsg:
@@ -406,7 +415,6 @@ func (a App) handleDataMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		return a, nil, true
 
 	case nodesMsg:
-		a.heavyDone()
 		a.store.SetNodes(msg.nodes, msg.gen, msg.err)
 		a.observe(store.SectionNodes, msg.err)
 		a.nodes.Refresh()
@@ -415,7 +423,6 @@ func (a App) handleDataMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		return a, nil, true
 
 	case allUsersJobsMsg:
-		a.heavyDone()
 		a.store.SetAllUsersJobs(msg.jobs, msg.gen, msg.err)
 		a.observe(store.SectionAllUsersJobs, msg.err)
 		a.jobs.Refresh()   // My-Usage banner derives from all-users jobs.
@@ -425,7 +432,6 @@ func (a App) handleDataMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		return a, nil, true
 
 	case fairShareMsg:
-		a.heavyDone()
 		a.store.SetFairShare(msg.entries, msg.gen, msg.err)
 		a.observe(store.SectionFairShare, msg.err)
 		a.priority.Refresh()
@@ -433,7 +439,6 @@ func (a App) handleDataMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		return a, nil, true
 
 	case pendingPrioMsg:
-		a.heavyDone()
 		a.store.SetPendingPrio(msg.entries, msg.gen, msg.err)
 		a.observe(store.SectionPendingPrio, msg.err)
 		a.priority.Refresh()
@@ -520,19 +525,16 @@ func (a App) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if idx, ok := tabForKey(msg); ok {
-		a.active = idx
-		a.frame.dirty = true
-		return a, nil
+		cmd := a.setActive(idx)
+		return a, cmd
 	}
 	switch msg.String() {
 	case "tab":
-		a.active = (a.active + 1) % numTabs
-		a.frame.dirty = true
-		return a, nil
+		cmd := a.setActive((a.active + 1) % numTabs)
+		return a, cmd
 	case "shift+tab":
-		a.active = (a.active + numTabs - 1) % numTabs
-		a.frame.dirty = true
-		return a, nil
+		cmd := a.setActive((a.active + numTabs - 1) % numTabs)
+		return a, cmd
 	}
 
 	return a.routeToActive(msg)
@@ -641,14 +643,34 @@ func tabForKey(msg tea.KeyPressMsg) (tabIndex, bool) {
 	return 0, false
 }
 
-// manualRefresh re-dispatches the running and heavy waves, bumping their
-// generations so superseded in-flight results are dropped (I4). Each wave is
-// skipped while it is already in flight: re-dispatching the heavy wave mid-flight
-// would reset heavyPending under the outstanding fetches and clear the guard
-// early, letting the next slow tick pile on a third wave. History refreshes from
-// the controller journal (throttled at the client), so it is always re-run
-// without ever touching slurmdbd. The caller owns user-visible feedback (the 'r'
-// key pushes a toast), since re-fetching alone is not visible while data is on
+// setActive switches the active tab to idx (a no-op when it is already active) and
+// fetches any heavy data the new tab needs but that went unpolled while it was
+// hidden, so the tab shows fresh data on arrival rather than waiting for the next
+// slow tick. Nodes and all-users are polled every tick regardless, so only the
+// Priority/Users fair-share + pending-priority become newly needed; they are
+// fetched when entering one of those tabs from outside. The dispatch self-skips
+// while its section is already loading, bounding the cost of rapid tab cycling.
+func (a *App) setActive(idx tabIndex) tea.Cmd {
+	if idx == a.active {
+		return nil
+	}
+	prev := a.active
+	a.active = idx
+	a.frame.dirty = true
+	if a.tabNeedsPriorityData(idx) && !a.tabNeedsPriorityData(prev) {
+		return tea.Batch(a.dispatchSection(store.SectionFairShare), a.dispatchSection(store.SectionPendingPrio), a.ensureSpinner())
+	}
+	return nil
+}
+
+// manualRefresh re-fetches the running jobs, the journal history, and the visible
+// heavy data, bumping their generations so superseded in-flight results are
+// dropped (I4). The running fetch is skipped while one is in flight; the heavy
+// fetches self-skip per section while already loading (dispatchSection), and only
+// the data the visible UI needs is refreshed (dispatchHeavyVisible). History
+// refreshes from the controller journal (throttled at the client), so it is always
+// re-run without ever touching slurmdbd. The caller owns user-visible feedback (the
+// 'r' key pushes a toast), since re-fetching alone is not visible while data is on
 // screen.
 func (a *App) manualRefresh() tea.Cmd {
 	a.frame.dirty = true
@@ -656,10 +678,7 @@ func (a *App) manualRefresh() tea.Cmd {
 	if !a.runningInFlight {
 		cmds = append(cmds, a.dispatchRunning())
 	}
-	if !a.heavyInFlight {
-		cmds = append(cmds, a.dispatchHeavy())
-	}
-	cmds = append(cmds, a.ensureSpinner())
+	cmds = append(cmds, a.dispatchHeavyVisible(), a.ensureSpinner())
 	return tea.Batch(cmds...)
 }
 
@@ -681,12 +700,13 @@ func (a App) handleFastTick() (tea.Model, tea.Cmd) {
 	return a, tea.Batch(cmds...)
 }
 
-// handleSlowTick dispatches the heavy batch when none is in flight and the
-// terminal is focused, and always re-arms exactly the slow tier (I2).
+// handleSlowTick dispatches the visible heavy fetches when the terminal is focused
+// and always re-arms exactly the slow tier (I2). Each fetch self-skips while its
+// section is already loading, so a tick never stacks a duplicate.
 func (a App) handleSlowTick() (tea.Model, tea.Cmd) {
 	cmds := []tea.Cmd{slowTick(a.intervals.Slow)}
-	if !a.blurred && !a.heavyInFlight {
-		cmds = append(cmds, a.dispatchHeavy())
+	if !a.blurred {
+		cmds = append(cmds, a.dispatchHeavyVisible())
 	}
 	cmds = append(cmds, a.ensureSpinner())
 	return a, tea.Batch(cmds...)

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -170,6 +170,77 @@ func TestHeavyGuardClearsOnlyAfterAllFetchesReturn(t *testing.T) {
 	}
 }
 
+// TestBlurStopsPollingButKeepsTicking asserts a blurred terminal stops dispatching
+// Slurm fetches on both tiers while still re-arming each ticker, and that regaining
+// focus resumes with a refresh.
+func TestBlurStopsPollingButKeepsTicking(t *testing.T) {
+	a := newTestApp(t, &store.FakeClient{})
+
+	m, _ := a.Update(tea.BlurMsg{})
+	a = m.(App)
+
+	_, fcmd := a.Update(fastTickMsg{at: time.Now()})
+	fmsgs := drainCmd(fcmd)
+	if fast, _ := countTickMsgs(fmsgs); fast != 1 {
+		t.Errorf("blurred fast tick re-arms = %d; want 1", fast)
+	}
+	for _, msg := range fmsgs {
+		if _, ok := msg.(runningJobsMsg); ok {
+			t.Error("blurred fast tick dispatched a running-jobs fetch")
+		}
+	}
+
+	_, scmd := a.Update(slowTickMsg{at: time.Now()})
+	smsgs := drainCmd(scmd)
+	if _, slow := countTickMsgs(smsgs); slow != 1 {
+		t.Errorf("blurred slow tick re-arms = %d; want 1", slow)
+	}
+	for _, msg := range smsgs {
+		switch msg.(type) {
+		case nodesMsg, allUsersJobsMsg, fairShareMsg, pendingPrioMsg:
+			t.Error("blurred slow tick dispatched a heavy fetch")
+		}
+	}
+
+	// Regaining focus dispatches a refresh wave immediately.
+	_, focusCmd := a.Update(tea.FocusMsg{})
+	var resumed bool
+	for _, msg := range drainCmd(focusCmd) {
+		switch msg.(type) {
+		case runningJobsMsg, nodesMsg, historyMsg:
+			resumed = true
+		}
+	}
+	if !resumed {
+		t.Error("regaining focus did not dispatch a refresh")
+	}
+}
+
+// TestManualRefreshSkipsHeavyWhileInFlight asserts manualRefresh does not pile a
+// second heavy wave on top of one already in flight — which would reset
+// heavyPending under the outstanding fetches and let a slow tick add a third.
+func TestManualRefreshSkipsHeavyWhileInFlight(t *testing.T) {
+	a := newTestApp(t, &store.FakeClient{})
+	a.heavyInFlight = true
+	a.heavyPending = heavyFetchCount
+	genBefore := a.store.Gen(store.SectionNodes)
+
+	cmd := a.manualRefresh()
+
+	for _, msg := range drainCmd(cmd) {
+		switch msg.(type) {
+		case nodesMsg, allUsersJobsMsg, fairShareMsg, pendingPrioMsg:
+			t.Error("manualRefresh dispatched a heavy fetch while the wave was in flight")
+		}
+	}
+	if g := a.store.Gen(store.SectionNodes); g != genBefore {
+		t.Errorf("nodes generation bumped (%d→%d) by a skipped heavy dispatch", genBefore, g)
+	}
+	if a.heavyPending != heavyFetchCount {
+		t.Errorf("heavyPending = %d; want %d (untouched while in flight)", a.heavyPending, heavyFetchCount)
+	}
+}
+
 // TestUnavailableScreenRendered asserts that an unavailable client makes the
 // model render the full-screen unavailable screen rather than the tab bar.
 func TestUnavailableScreenRendered(t *testing.T) {

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -120,7 +120,6 @@ func TestFastTickReArmsButSkipsFetchWhenInFlight(t *testing.T) {
 // TestSlowTickReArmsOwnTierExactlyOnce asserts I2 for the slow tier.
 func TestSlowTickReArmsOwnTierExactlyOnce(t *testing.T) {
 	a := newTestApp(t, &store.FakeClient{})
-	a.heavyInFlight = false
 
 	_, cmd := a.Update(slowTickMsg{at: time.Now()})
 	msgs := drainCmd(cmd)
@@ -134,39 +133,92 @@ func TestSlowTickReArmsOwnTierExactlyOnce(t *testing.T) {
 	}
 }
 
-// TestHeavyGuardClearsOnlyAfterAllFetchesReturn asserts the in-flight guard is
-// cleared only once every heavy fetch has returned — not when whichever finishes
-// first does. Otherwise a slow tick would re-dispatch the heavy wave while fetches
-// are still running.
-func TestHeavyGuardClearsOnlyAfterAllFetchesReturn(t *testing.T) {
+// TestDispatchHeavyVisibleByTab pins the visibility predicate: nodes and all-users
+// are always polled (they feed the sidebar / 'L' modal / banners), while
+// fair-share and pending-priority are polled only while the Priority or Users tab
+// is active.
+func TestDispatchHeavyVisibleByTab(t *testing.T) {
+	cases := []struct {
+		name   string
+		active tabIndex
+		want   map[string]bool
+	}{
+		{"jobs", tabJobs, map[string]bool{"nodes": true, "allusers": true}},
+		{"nodes", tabNodes, map[string]bool{"nodes": true, "allusers": true}},
+		{"logs", tabLogs, map[string]bool{"nodes": true, "allusers": true}},
+		{"priority", tabPriority, map[string]bool{"nodes": true, "allusers": true, "fairshare": true, "pendingprio": true}},
+		{"users", tabUsers, map[string]bool{"nodes": true, "allusers": true, "fairshare": true, "pendingprio": true}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := newTestApp(t, &store.FakeClient{})
+			a.active = tc.active
+			got := map[string]bool{}
+			for _, msg := range drainCmd(a.dispatchHeavyVisible()) {
+				switch msg.(type) {
+				case nodesMsg:
+					got["nodes"] = true
+				case allUsersJobsMsg:
+					got["allusers"] = true
+				case fairShareMsg:
+					got["fairshare"] = true
+				case pendingPrioMsg:
+					got["pendingprio"] = true
+				}
+			}
+			for _, s := range []string{"nodes", "allusers", "fairshare", "pendingprio"} {
+				if got[s] != tc.want[s] {
+					t.Errorf("section %q dispatched=%v, want=%v", s, got[s], tc.want[s])
+				}
+			}
+		})
+	}
+}
+
+// TestHeavySectionGuardSkipsWhileLoading asserts a needed section already loading
+// is not re-dispatched (the per-section replacement for the old monolithic guard).
+func TestHeavySectionGuardSkipsWhileLoading(t *testing.T) {
 	a := newTestApp(t, &store.FakeClient{})
-	a.heavyInFlight = true
-	a.heavyPending = heavyFetchCount
 
-	g := func(s store.Section) uint64 { return a.store.Gen(s) }
-	// Three of four results arrive. The guard must stay set, so handleSlowTick
-	// (which checks !heavyInFlight) cannot re-dispatch.
-	partial := []tea.Msg{
-		nodesMsg{gen: g(store.SectionNodes)},
-		allUsersJobsMsg{gen: g(store.SectionAllUsersJobs)},
-		fairShareMsg{gen: g(store.SectionFairShare)},
-	}
-	cur := a
-	for _, msg := range partial {
-		next, _ := cur.Update(msg)
-		cur = next.(App)
-	}
-	if !cur.heavyInFlight {
-		t.Fatal("heavyInFlight cleared after only 3/4 heavy results returned")
-	}
-	if cur.heavyPending != 1 {
-		t.Fatalf("heavyPending = %d after 3 results; want 1", cur.heavyPending)
-	}
+	gNodes := a.store.NextGen(store.SectionNodes)
+	a.store.SetLoading(store.SectionNodes, gNodes)
 
-	// The fourth result clears the guard.
-	next, _ := cur.Update(pendingPrioMsg{gen: g(store.SectionPendingPrio)})
-	if next.(App).heavyInFlight {
-		t.Error("heavyInFlight still set after all 4 heavy results returned")
+	var sawNodes, sawAllUsers bool
+	for _, msg := range drainCmd(a.dispatchHeavyVisible()) {
+		switch msg.(type) {
+		case nodesMsg:
+			sawNodes = true
+		case allUsersJobsMsg:
+			sawAllUsers = true
+		}
+	}
+	if sawNodes {
+		t.Error("re-dispatched nodes while it was already loading")
+	}
+	if !sawAllUsers {
+		t.Error("did not dispatch all-users jobs (not loading, sidebar visible)")
+	}
+	if got := a.store.Gen(store.SectionNodes); got != gNodes {
+		t.Errorf("nodes generation bumped (%d→%d) while loading", gNodes, got)
+	}
+}
+
+// TestSetActiveSwitchesAndNoOps asserts a tab switch updates the active tab and
+// returns a fetch for the newly-visible data, while re-selecting the active tab is
+// a no-op.
+func TestSetActiveSwitchesAndNoOps(t *testing.T) {
+	a := newTestApp(t, &store.FakeClient{})
+	a.active = tabJobs
+
+	cmd := a.setActive(tabPriority)
+	if a.active != tabPriority {
+		t.Fatalf("active = %v, want tabPriority", a.active)
+	}
+	if cmd == nil {
+		t.Error("switching tabs returned nil; want a fetch for the newly-visible data")
+	}
+	if cmd := a.setActive(tabPriority); cmd != nil {
+		t.Error("setActive to the already-active tab returned a non-nil Cmd")
 	}
 }
 
@@ -216,28 +268,20 @@ func TestBlurStopsPollingButKeepsTicking(t *testing.T) {
 	}
 }
 
-// TestManualRefreshSkipsHeavyWhileInFlight asserts manualRefresh does not pile a
-// second heavy wave on top of one already in flight — which would reset
-// heavyPending under the outstanding fetches and let a slow tick add a third.
-func TestManualRefreshSkipsHeavyWhileInFlight(t *testing.T) {
+// TestManualRefreshSkipsLoadingSection asserts manualRefresh does not re-dispatch a
+// heavy section already loading — the per-section guard that replaced the old
+// heavyPending counter (whose miscount let a slow tick stack a third wave).
+func TestManualRefreshSkipsLoadingSection(t *testing.T) {
 	a := newTestApp(t, &store.FakeClient{})
-	a.heavyInFlight = true
-	a.heavyPending = heavyFetchCount
-	genBefore := a.store.Gen(store.SectionNodes)
+	a.active = tabJobs // narrow: dispatchHeavyVisible needs only all-users jobs
 
-	cmd := a.manualRefresh()
+	g := a.store.NextGen(store.SectionAllUsersJobs)
+	a.store.SetLoading(store.SectionAllUsersJobs, g)
 
-	for _, msg := range drainCmd(cmd) {
-		switch msg.(type) {
-		case nodesMsg, allUsersJobsMsg, fairShareMsg, pendingPrioMsg:
-			t.Error("manualRefresh dispatched a heavy fetch while the wave was in flight")
-		}
-	}
-	if g := a.store.Gen(store.SectionNodes); g != genBefore {
-		t.Errorf("nodes generation bumped (%d→%d) by a skipped heavy dispatch", genBefore, g)
-	}
-	if a.heavyPending != heavyFetchCount {
-		t.Errorf("heavyPending = %d; want %d (untouched while in flight)", a.heavyPending, heavyFetchCount)
+	a.manualRefresh()
+
+	if got := a.store.Gen(store.SectionAllUsersJobs); got != g {
+		t.Errorf("all-users generation bumped (%d→%d); manualRefresh must skip a loading section", g, got)
 	}
 }
 

--- a/internal/ui/completions_test.go
+++ b/internal/ui/completions_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/pjhartout/stoei/internal/store"
@@ -57,5 +58,40 @@ func TestRunningJobsNoCompletionsNoLookup(t *testing.T) {
 
 	if fc.LastCompletedJobID != "" {
 		t.Errorf("looked up %q, want no lookup for an unchanged running set", fc.LastCompletedJobID)
+	}
+}
+
+// TestLargeCompletionBurstUsesBulkHistory asserts that when more than
+// completionBulkThreshold jobs vanish in one refresh (a draining array), the app
+// issues a single bulk history refresh instead of one controller lookup per job.
+func TestLargeCompletionBurstUsesBulkHistory(t *testing.T) {
+	fc := &store.FakeClient{}
+	a := newTestApp(t, fc)
+
+	big := make([]store.RunningJob, 0, completionBulkThreshold+2)
+	for i := 0; i < completionBulkThreshold+2; i++ {
+		big = append(big, store.RunningJob{ID: fmt.Sprintf("job-%d", i)})
+	}
+	m, _ := a.Update(runningJobsMsg{gen: 1, jobs: big})
+	a = m.(App)
+	_, cmd := a.Update(runningJobsMsg{gen: 2, jobs: nil}) // the whole set vanishes at once
+
+	var sawHistory, sawCompleted bool
+	for _, msg := range drainCmd(cmd) {
+		switch msg.(type) {
+		case historyMsg:
+			sawHistory = true
+		case completedJobMsg:
+			sawCompleted = true
+		}
+	}
+	if !sawHistory {
+		t.Error("large completion burst did not trigger a bulk history refresh")
+	}
+	if sawCompleted {
+		t.Error("large burst issued per-job controller lookups; want one bulk refresh")
+	}
+	if fc.LastCompletedJobID != "" {
+		t.Errorf("per-job lookup happened (%q); want none for a bulk burst", fc.LastCompletedJobID)
 	}
 }

--- a/internal/ui/tick.go
+++ b/internal/ui/tick.go
@@ -10,7 +10,7 @@ import (
 // tier (4x the fast interval) drives the heavy batch sections. These are the
 // fallback defaults; the live intervals are derived from the user config.
 const (
-	defaultFastInterval = 5 * time.Second
+	defaultFastInterval = 10 * time.Second
 	slowIntervalFactor  = 4
 )
 
@@ -21,7 +21,7 @@ type Intervals struct {
 	Slow time.Duration
 }
 
-// DefaultIntervals returns the locked default refresh intervals (5s fast, 20s
+// DefaultIntervals returns the locked default refresh intervals (10s fast, 40s
 // slow).
 func DefaultIntervals() Intervals {
 	return Intervals{

--- a/internal/ui/tick_test.go
+++ b/internal/ui/tick_test.go
@@ -7,11 +7,11 @@ import (
 
 func TestDefaultIntervals(t *testing.T) {
 	iv := DefaultIntervals()
-	if iv.Fast != 5*time.Second {
-		t.Errorf("fast = %v; want 5s", iv.Fast)
+	if iv.Fast != 10*time.Second {
+		t.Errorf("fast = %v; want 10s", iv.Fast)
 	}
-	if iv.Slow != 20*time.Second {
-		t.Errorf("slow = %v; want 20s", iv.Slow)
+	if iv.Slow != 40*time.Second {
+		t.Errorf("slow = %v; want 40s", iv.Slow)
 	}
 	if iv.Slow != iv.Fast*slowIntervalFactor {
 		t.Errorf("slow (%v) != fast*%d (%v)", iv.Slow, slowIntervalFactor, iv.Fast*slowIntervalFactor)

--- a/internal/ui/toast.go
+++ b/internal/ui/toast.go
@@ -23,9 +23,9 @@ const (
 )
 
 // toastTTL is how many fast ticks a toast remains visible before it auto-expires.
-// At the default ~5s fast interval this keeps a toast on screen for a few cycles
-// without lingering indefinitely.
-const toastTTL = 3
+// At the default 10s fast interval this keeps a transient notice on screen ~20s —
+// long enough to read, short enough not to linger after the action it reported.
+const toastTTL = 2
 
 // toastItem is one transient on-screen toast: its text, severity level, and the
 // number of fast ticks remaining before it auto-expires.


### PR DESCRIPTION
Reduces how often stoei shells out to the Slurm controller, without changing the async-responsiveness design.

- **Focus/blur backoff**: while the terminal reports lost focus, both tick tiers keep re-arming but skip dispatching squeue/scontrol, so a backgrounded session stops polling (~24 → ~0 cmd/min). Regaining focus refreshes immediately. Terminals that don't report focus are unaffected.
- **Completion-burst coalescing**: when more than a small threshold of jobs leave the queue in one refresh (a draining array), do one bulk `scontrol show jobs` refresh instead of one `scontrol show jobid` per job — also removes the old 64-lookup cap that silently dropped the overflow.
- **Default interval 5s → 10s** (slow tier 40s), halving the steady-state poll rate. Still user-overridable in config.
- **Per-section dispatch guards** replace the monolithic heavy in-flight guard (fixing a `heavyPending` miscount that could stack a third wave), and **fair-share/pending-priority are polled only while the Priority or Users tab is active** (their only consumers), with an immediate fetch on entering those tabs. Nodes and all-users stay always-polled — they feed the sidebar, the `L` cluster-load modal, and the banners. On the common Jobs/Nodes/Logs tabs the heavy tier drops from four commands to two.

Verified by an adversarial review pass (consumer coverage, dispatch correctness, load/UX): no starved consumers, no stuck-loading leak, invariants I2/I4 preserved.