### PR TITLE
fix(go): persist mid-session completions to the journal

### DIFF
--- a/internal/slurm/client.go
+++ b/internal/slurm/client.go
@@ -316,6 +316,14 @@ func (c *Client) CompletedJobRecord(ctx context.Context, jobID string) (HistoryJ
 	if f["JobId"] == "" || !IsTerminalState(f["JobState"]) {
 		return HistoryJob{}, false, nil
 	}
+	// Persist the terminal record to the journal so the final state survives a
+	// restart. The in-memory completion overlay does not, and "scontrol show jobs"
+	// may never observe this job again once the controller ages it out (MinJobAge),
+	// so without this the journal keeps its last RUNNING snapshot. Best-effort: a
+	// journal write must not fail the lookup.
+	if c.journal != nil {
+		_ = c.journal.upsert([]ControllerJob{controllerJobFromFields(f)})
+	}
 	return HistoryJob{
 		ID:       jobID,
 		Name:     f["JobName"],

--- a/internal/slurm/controller.go
+++ b/internal/slurm/controller.go
@@ -39,24 +39,32 @@ func ParseControllerJobs(raw string) []ControllerJob {
 		if f["JobId"] == "" {
 			continue
 		}
-		jobs = append(jobs, ControllerJob{
-			ID:        controllerJobID(f),
-			User:      userName(f["UserId"]),
-			Name:      f["JobName"],
-			State:     baseState(f["JobState"]),
-			Partition: f["Partition"],
-			Submit:    f["SubmitTime"],
-			Start:     f["StartTime"],
-			End:       f["EndTime"],
-			Elapsed:   f["RunTime"],
-			ExitCode:  f["ExitCode"],
-			Restart:   f["Restarts"],
-			NodeList:  f["NodeList"],
-			NCPUS:     f["NumCPUs"],
-			AllocTRES: f["TRES"],
-		})
+		jobs = append(jobs, controllerJobFromFields(f))
 	}
 	return jobs
+}
+
+// controllerJobFromFields builds a ControllerJob from one parsed scontrol
+// Key=Value block. The id is keyed to match squeue %i (controllerJobID) and the
+// state is reduced to its base token, so a single "scontrol show jobid" block and
+// a block from "scontrol show jobs" yield the same shape.
+func controllerJobFromFields(f map[string]string) ControllerJob {
+	return ControllerJob{
+		ID:        controllerJobID(f),
+		User:      userName(f["UserId"]),
+		Name:      f["JobName"],
+		State:     baseState(f["JobState"]),
+		Partition: f["Partition"],
+		Submit:    f["SubmitTime"],
+		Start:     f["StartTime"],
+		End:       f["EndTime"],
+		Elapsed:   f["RunTime"],
+		ExitCode:  f["ExitCode"],
+		Restart:   f["Restarts"],
+		NodeList:  f["NodeList"],
+		NCPUS:     f["NumCPUs"],
+		AllocTRES: f["TRES"],
+	}
 }
 
 // controllerJobID returns the job id keyed to match squeue %i. A dispatched

--- a/internal/slurm/journal_test.go
+++ b/internal/slurm/journal_test.go
@@ -1,10 +1,42 @@
 package slurm
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+// TestCompletedJobRecordPersistsToJournal asserts a mid-session completion observed
+// via "scontrol show jobid" is written to the durable journal, so its terminal
+// state survives a restart instead of reverting to the last RUNNING snapshot.
+func TestCompletedJobRecordPersistsToJournal(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "jobs.jsonl")
+	out := "JobId=777 JobName=train UserId=alice(1000) JobState=COMPLETED " +
+		"ExitCode=0:0 Restarts=0 RunTime=01:00:00 NodeList=n01 " +
+		"SubmitTime=2024-01-15T06:00:00 StartTime=2024-01-15T06:05:00 EndTime=2024-01-15T07:05:00"
+	r := &fixtureRunner{outputs: map[string]string{"scontrol": out}}
+	c := NewClient(r, WithUsername("alice"), WithJournal(path))
+
+	if _, found, err := c.CompletedJobRecord(context.Background(), "777"); err != nil || !found {
+		t.Fatalf("CompletedJobRecord: found=%v err=%v", found, err)
+	}
+
+	// Re-read the journal from disk, as a restart would.
+	var rec *ControllerJob
+	for _, j := range newJobJournal(path).all() {
+		if j.ID == "777" {
+			j := j
+			rec = &j
+		}
+	}
+	if rec == nil {
+		t.Fatal("job 777 was not persisted to the journal (its completion is lost on restart)")
+	}
+	if !IsTerminalState(rec.State) {
+		t.Errorf("journal state for 777 = %q, want a terminal state", rec.State)
+	}
+}
 
 func TestParseControllerJobs(t *testing.T) {
 	jobs := ParseControllerJobs(loadFixture(t, "scontrol_jobs.txt"))


### PR DESCRIPTION
A job observed finishing mid-session via `scontrol show jobid` (`CompletedJobRecord`) was recorded only in the in-memory completion overlay, never in the on-disk journal. The journal is written solely by `scontrol show jobs` (throttled, runs at startup/manual-refresh), which usually runs after the controller has aged the finished job out (`MinJobAge`) — so it never sees the terminal state and keeps its last `RUNNING` snapshot. On restart the overlay is gone, history loads the stale `RUNNING`, and (since v0.7.4) it renders as `UNKNOWN`.

`CompletedJobRecord` now upserts the terminal record into the journal at observation time (best-effort), so the final state survives a restart. Extracts `controllerJobFromFields` so a `show jobid` block and a `show jobs` block yield the same shape, keeping array-task ids aligned with squeue.

Jobs that age out before any lookup ever observes them terminal still cannot be recovered (no sacct) and remain `UNKNOWN` — honest, since the outcome was never observed.