### PR TITLE
fix(go): keep the live running list refreshing regardless of focus

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -101,11 +101,6 @@ type App struct {
 	// spinnerActive is true while the loading-spinner animation tick is in flight,
 	// so it is started at most once and stopped when nothing is loading.
 	spinnerActive bool
-	// blurred is true while the terminal reports it has lost focus. Both tick tiers
-	// keep re-arming but skip dispatching Slurm fetches while blurred, so a
-	// backgrounded session stops polling the controller; regaining focus triggers an
-	// immediate refresh. Terminals that do not report focus never set it.
-	blurred bool
 
 	// unavailable holds the Slurm-availability error; non-nil renders the
 	// full-screen unavailable screen.
@@ -348,14 +343,6 @@ func (a App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyPressMsg:
 		return a.handleKey(msg)
-
-	case tea.FocusMsg:
-		a.blurred = false
-		return a, a.manualRefresh() // resume with fresh data on return
-
-	case tea.BlurMsg:
-		a.blurred = true
-		return a, nil
 
 	case availabilityMsg:
 		a.availChecked = true
@@ -682,12 +669,14 @@ func (a *App) manualRefresh() tea.Cmd {
 	return tea.Batch(cmds...)
 }
 
-// handleFastTick dispatches a running-jobs refresh when none is in flight and the
-// terminal is focused, and always re-arms exactly the fast tier (I2) so polling
-// resumes the instant focus returns.
+// handleFastTick dispatches a running-jobs refresh when none is in flight and
+// always re-arms exactly the fast tier (I2). The live squeue list is never gated
+// on terminal focus: focus is not visibility (a visible-but-unfocused pane — a
+// tmux split, a tiling layout — would otherwise silently freeze), so the primary
+// list the user watches always refreshes.
 func (a App) handleFastTick() (tea.Model, tea.Cmd) {
 	cmds := []tea.Cmd{fastTick(a.intervals.Fast)}
-	if !a.blurred && !a.runningInFlight {
+	if !a.runningInFlight {
 		cmds = append(cmds, a.dispatchRunning())
 	}
 	// Auto-expire transient toasts each cycle so they don't linger indefinitely.
@@ -700,15 +689,13 @@ func (a App) handleFastTick() (tea.Model, tea.Cmd) {
 	return a, tea.Batch(cmds...)
 }
 
-// handleSlowTick dispatches the visible heavy fetches when the terminal is focused
-// and always re-arms exactly the slow tier (I2). Each fetch self-skips while its
-// section is already loading, so a tick never stacks a duplicate.
+// handleSlowTick dispatches the visible heavy fetches and always re-arms exactly
+// the slow tier (I2). Each fetch self-skips while its section is already loading,
+// so a tick never stacks a duplicate. Controller load is bounded by tab visibility
+// (dispatchHeavyVisible) — what is actually on screen — not by terminal focus.
 func (a App) handleSlowTick() (tea.Model, tea.Cmd) {
 	cmds := []tea.Cmd{slowTick(a.intervals.Slow)}
-	if !a.blurred {
-		cmds = append(cmds, a.dispatchHeavyVisible())
-	}
-	cmds = append(cmds, a.ensureSpinner())
+	cmds = append(cmds, a.dispatchHeavyVisible(), a.ensureSpinner())
 	return a, tea.Batch(cmds...)
 }
 
@@ -994,7 +981,6 @@ func (a App) View() tea.View {
 
 	v := tea.NewView(content)
 	v.AltScreen = true
-	v.ReportFocus = true // drive the focus/blur backoff (handleFastTick/handleSlowTick)
 	return v
 }
 

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -222,49 +222,27 @@ func TestSetActiveSwitchesAndNoOps(t *testing.T) {
 	}
 }
 
-// TestBlurStopsPollingButKeepsTicking asserts a blurred terminal stops dispatching
-// Slurm fetches on both tiers while still re-arming each ticker, and that regaining
-// focus resumes with a refresh.
-func TestBlurStopsPollingButKeepsTicking(t *testing.T) {
+// TestTerminalBlurDoesNotFreezeLiveList asserts the live running tier keeps
+// polling regardless of terminal focus: a tea.BlurMsg must not stop the fast-tier
+// squeue dispatch, since focus is not visibility (a visible-but-unfocused pane
+// would otherwise freeze the list the user is watching).
+func TestTerminalBlurDoesNotFreezeLiveList(t *testing.T) {
 	a := newTestApp(t, &store.FakeClient{})
 
+	// A blur event is now an ordinary, ignored message; it must not latch any state
+	// that suppresses dispatch.
 	m, _ := a.Update(tea.BlurMsg{})
 	a = m.(App)
 
-	_, fcmd := a.Update(fastTickMsg{at: time.Now()})
-	fmsgs := drainCmd(fcmd)
-	if fast, _ := countTickMsgs(fmsgs); fast != 1 {
-		t.Errorf("blurred fast tick re-arms = %d; want 1", fast)
-	}
-	for _, msg := range fmsgs {
+	_, cmd := a.Update(fastTickMsg{at: time.Now()})
+	var sawRunningFetch bool
+	for _, msg := range drainCmd(cmd) {
 		if _, ok := msg.(runningJobsMsg); ok {
-			t.Error("blurred fast tick dispatched a running-jobs fetch")
+			sawRunningFetch = true
 		}
 	}
-
-	_, scmd := a.Update(slowTickMsg{at: time.Now()})
-	smsgs := drainCmd(scmd)
-	if _, slow := countTickMsgs(smsgs); slow != 1 {
-		t.Errorf("blurred slow tick re-arms = %d; want 1", slow)
-	}
-	for _, msg := range smsgs {
-		switch msg.(type) {
-		case nodesMsg, allUsersJobsMsg, fairShareMsg, pendingPrioMsg:
-			t.Error("blurred slow tick dispatched a heavy fetch")
-		}
-	}
-
-	// Regaining focus dispatches a refresh wave immediately.
-	_, focusCmd := a.Update(tea.FocusMsg{})
-	var resumed bool
-	for _, msg := range drainCmd(focusCmd) {
-		switch msg.(type) {
-		case runningJobsMsg, nodesMsg, historyMsg:
-			resumed = true
-		}
-	}
-	if !resumed {
-		t.Error("regaining focus did not dispatch a refresh")
+	if !sawRunningFetch {
+		t.Error("a blurred fast tick did not dispatch a running-jobs fetch (the live list would freeze)")
 	}
 }
 

--- a/internal/ui/tabs/jobs.go
+++ b/internal/ui/tabs/jobs.go
@@ -433,6 +433,12 @@ func reselect(t *table.Model, sorted [][]string, id string) {
 // View renders the My-Usage banner, the optional filter input, and the table.
 func (j *Jobs) View() string {
 	banner := j.styles.Subtle.Render(j.banner())
+	// When the last squeue fetch failed but prior rows are still on screen, mark
+	// them stale: SetRunningJobs keeps the previous snapshot on error, so without
+	// this the list looks live while it is frozen at the last good fetch.
+	if j.store.State(store.SectionRunningJobs) == store.StateError && len(j.store.RunningJobs) > 0 {
+		banner += "  " + j.styles.Error.Render("⚠ squeue failed — showing last known jobs")
+	}
 
 	parts := []string{banner, ""}
 	if j.filtering {

--- a/internal/ui/tabs/jobs_test.go
+++ b/internal/ui/tabs/jobs_test.go
@@ -1,6 +1,7 @@
 package tabs
 
 import (
+	"errors"
 	"regexp"
 	"strings"
 	"testing"
@@ -10,6 +11,26 @@ import (
 	"github.com/pjhartout/stoei/internal/store"
 	"github.com/pjhartout/stoei/internal/ui/theme"
 )
+
+// TestStaleSqueueBannerWhenErrorWithData asserts that when the latest squeue fetch
+// fails but prior running rows remain on screen, the Jobs view marks them stale so
+// the still-rendered list is not silently trusted.
+func TestStaleSqueueBannerWhenErrorWithData(t *testing.T) {
+	j, st := seedJobs(t, []store.RunningJob{
+		{ID: "1", Name: "train", State: "RUNNING", Time: "1:00", Nodes: "1", NodeList: "n01"},
+	})
+	if strings.Contains(j.View(), "squeue failed") {
+		t.Fatal("stale banner shown while the section is healthy")
+	}
+
+	// A later squeue fetch fails; SetRunningJobs keeps the prior rows.
+	st.SetRunningJobs(nil, st.NextGen(store.SectionRunningJobs), errors.New("squeue down"))
+	j.Refresh()
+
+	if !strings.Contains(j.View(), "squeue failed") {
+		t.Errorf("stale banner missing after a squeue failure with rows present:\n%s", j.View())
+	}
+}
 
 // seedJobs builds a Jobs tab over a store seeded with the given running jobs.
 func seedJobs(t *testing.T, jobs []store.RunningJob) (*Jobs, *store.Store) {


### PR DESCRIPTION
Two trust bugs in the live running list, both from v0.7.4.

**Freeze (primary).** The focus/blur backoff gated the fast `squeue` tier on `a.blurred`, set by terminal focus events and cleared only on `FocusMsg`. Focus is not visibility: a visible-but-unfocused stoei (tmux split, tiling WM, side-by-side window) gets a blur, stops dispatching `squeue`, and keeps redrawing the frozen snapshot — the list looks live but is stale, and never recovers if a focus event never arrives. Removed the focus/blur backoff entirely (field, `FocusMsg`/`BlurMsg` handlers, `ReportFocus`, and both `!a.blurred` guards); the live list refreshes every tick. The tab-visibility gating (heavy sshare/sprio scoped to their tabs) is kept — it keys off on-screen state, not focus.

**Silent stale-on-error (compounding).** On a `squeue` failure `SetRunningJobs` keeps the prior rows (correct), but the status badge was suppressed whenever rows were present, so an intermittent failure showed last-known jobs as if live. The Jobs banner now shows `⚠ squeue failed — showing last known jobs` when the latest fetch errored with rows on screen.

Regression tests: a blurred fast tick must still dispatch the running fetch; a squeue error with rows present must show the stale banner.