### PR TITLE
fix(go): auto-reconcile completed jobs without a manual refresh

### DIFF
--- a/internal/store/completed_test.go
+++ b/internal/store/completed_test.go
@@ -64,6 +64,36 @@ func TestAddCompletedJobMergesAndSacctAbsorbs(t *testing.T) {
 	}
 }
 
+// TestHistoryRefreshHealsStaleRunningToTerminal asserts a periodic history refresh
+// promotes a job the merge had relabeled UNKNOWN (a stale RUNNING base snapshot for
+// a job no longer in the queue) to its real terminal state — i.e. the slow-tick
+// history reconcile fixes a completion the overlay missed, without a manual refresh.
+func TestHistoryRefreshHealsStaleRunningToTerminal(t *testing.T) {
+	s := New()
+	// squeue has loaded (relabel active) and the job is no longer running.
+	s.SetRunningJobs(nil, s.NextGen(SectionRunningJobs), nil)
+	// The startup history snapshot still has the job as RUNNING.
+	s.SetHistory([]slurm.HistoryJob{{ID: "7", State: "RUNNING"}}, slurm.HistoryStats{}, s.NextGen(SectionHistory), nil)
+	if got := mergedStateByID(s, "7"); got != "UNKNOWN" {
+		t.Fatalf("pre-reconcile state for job 7 = %q, want UNKNOWN", got)
+	}
+
+	// A later history refresh observes the terminal record.
+	s.SetHistory([]slurm.HistoryJob{{ID: "7", State: "COMPLETED", Elapsed: "1:00"}}, slurm.HistoryStats{}, s.NextGen(SectionHistory), nil)
+	if got := mergedStateByID(s, "7"); got != "COMPLETED" {
+		t.Errorf("post-reconcile state for job 7 = %q, want COMPLETED (history refresh must heal the stale row)", got)
+	}
+}
+
+func mergedStateByID(s *Store, id string) string {
+	for _, j := range s.MergedJobs() {
+		if j.ID == id {
+			return j.State
+		}
+	}
+	return ""
+}
+
 // TestAddCompletedJobSupersedesRunningBase covers the journal-era case: the
 // history base (sourced from the scontrol journal) carries a job that was
 // RUNNING when it was snapshotted. When that job finishes, the freshly observed

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -271,6 +271,17 @@ func (a *App) dispatchHistory() tea.Cmd {
 	return fetchHistory(a.client, gen, a.cfg.JobHistoryDays)
 }
 
+// dispatchHistoryIfIdle dispatches a history refresh unless one is already in
+// flight, so a slow tick or a tab-entry reconcile never stacks on an outstanding
+// fetch (and on a wave where Init/manualRefresh already dispatched history, this
+// self-skips). The controller call beneath it is throttled at the client (3s).
+func (a *App) dispatchHistoryIfIdle() tea.Cmd {
+	if a.store.State(store.SectionHistory) == store.StateLoading {
+		return nil
+	}
+	return a.dispatchHistory()
+}
+
 // dispatchHeavyVisible dispatches the heavy fetches whose data the UI can
 // currently surface, leaving the rest unpolled to keep load off the controller.
 // Nodes and all-users jobs are always refreshed: they feed the cluster sidebar,
@@ -278,13 +289,20 @@ func (a *App) dispatchHistory() tea.Cmd {
 // Users tab, so a consumer is reachable from any tab. Fair-share and
 // pending-priority are shown only on the Priority tab and the user/account detail
 // modals (reachable from the Priority and Users tabs), so they are polled only
-// while one of those tabs is active. Each fetch is guarded by its section's
-// StateLoading flag (dispatchSection), so a slow tick and a tab-switch fetch never
-// stack a duplicate, and generation tags drop any superseded result.
+// while one of those tabs is active. The job-history base (completed jobs) feeds
+// only the Jobs tab, so it is reconciled while that tab is visible — this is the
+// steady-state path that promotes a finished job to its terminal state when the
+// single-shot completion overlay missed it (e.g. the squeue-vs-scontrol COMPLETING
+// race). Each fetch is guarded by its section's StateLoading flag, so a slow tick
+// and a tab-switch fetch never stack a duplicate, and generation tags drop any
+// superseded result.
 func (a *App) dispatchHeavyVisible() tea.Cmd {
 	cmds := []tea.Cmd{
 		a.dispatchSection(store.SectionNodes),
 		a.dispatchSection(store.SectionAllUsersJobs),
+	}
+	if a.active == tabJobs {
+		cmds = append(cmds, a.dispatchHistoryIfIdle())
 	}
 	if a.tabNeedsPriorityData(a.active) {
 		cmds = append(cmds, a.dispatchSection(store.SectionFairShare), a.dispatchSection(store.SectionPendingPrio))
@@ -635,8 +653,9 @@ func tabForKey(msg tea.KeyPressMsg) (tabIndex, bool) {
 // hidden, so the tab shows fresh data on arrival rather than waiting for the next
 // slow tick. Nodes and all-users are polled every tick regardless, so only the
 // Priority/Users fair-share + pending-priority become newly needed; they are
-// fetched when entering one of those tabs from outside. The dispatch self-skips
-// while its section is already loading, bounding the cost of rapid tab cycling.
+// fetched when entering one of those tabs from outside, and the job history is
+// reconciled when returning to the Jobs tab. The dispatch self-skips while its
+// section is already loading, bounding the cost of rapid tab cycling.
 func (a *App) setActive(idx tabIndex) tea.Cmd {
 	if idx == a.active {
 		return nil
@@ -644,10 +663,19 @@ func (a *App) setActive(idx tabIndex) tea.Cmd {
 	prev := a.active
 	a.active = idx
 	a.frame.dirty = true
-	if a.tabNeedsPriorityData(idx) && !a.tabNeedsPriorityData(prev) {
-		return tea.Batch(a.dispatchSection(store.SectionFairShare), a.dispatchSection(store.SectionPendingPrio), a.ensureSpinner())
+	var cmds []tea.Cmd
+	if idx == tabJobs {
+		// History went unpolled while away; reconcile completed jobs on arrival.
+		cmds = append(cmds, a.dispatchHistoryIfIdle())
 	}
-	return nil
+	if a.tabNeedsPriorityData(idx) && !a.tabNeedsPriorityData(prev) {
+		cmds = append(cmds, a.dispatchSection(store.SectionFairShare), a.dispatchSection(store.SectionPendingPrio))
+	}
+	if len(cmds) == 0 {
+		return nil
+	}
+	cmds = append(cmds, a.ensureSpinner())
+	return tea.Batch(cmds...)
 }
 
 // manualRefresh re-fetches the running jobs, the journal history, and the visible

--- a/internal/ui/app_test.go
+++ b/internal/ui/app_test.go
@@ -222,6 +222,65 @@ func TestSetActiveSwitchesAndNoOps(t *testing.T) {
 	}
 }
 
+// TestSlowTickReconcilesHistoryOnJobsTab asserts the slow tier refreshes the job
+// history while the Jobs tab is visible, so a completion the single-shot overlay
+// missed self-heals without a manual refresh.
+func TestSlowTickReconcilesHistoryOnJobsTab(t *testing.T) {
+	a := newTestApp(t, &store.FakeClient{})
+	a.active = tabJobs
+	before := a.store.Gen(store.SectionHistory)
+
+	a.Update(slowTickMsg{at: time.Now()})
+
+	if a.store.Gen(store.SectionHistory) == before {
+		t.Error("slow tick on the Jobs tab did not reconcile history (completions would need manual refresh)")
+	}
+}
+
+// TestSlowTickSkipsHistoryOffJobsTab asserts history is not polled while the Jobs
+// tab is hidden (its only consumer), keeping controller load off.
+func TestSlowTickSkipsHistoryOffJobsTab(t *testing.T) {
+	a := newTestApp(t, &store.FakeClient{})
+	a.active = tabNodes
+	before := a.store.Gen(store.SectionHistory)
+
+	a.Update(slowTickMsg{at: time.Now()})
+
+	if a.store.Gen(store.SectionHistory) != before {
+		t.Error("slow tick off the Jobs tab dispatched a history fetch; it should stay unpolled")
+	}
+}
+
+// TestEnterJobsTabReconcilesHistory asserts returning to the Jobs tab reconciles
+// history immediately rather than waiting up to a slow interval.
+func TestEnterJobsTabReconcilesHistory(t *testing.T) {
+	a := newTestApp(t, &store.FakeClient{})
+	a.active = tabNodes
+	before := a.store.Gen(store.SectionHistory)
+
+	if cmd := a.setActive(tabJobs); cmd == nil {
+		t.Fatal("entering the Jobs tab returned no Cmd")
+	}
+	if a.store.Gen(store.SectionHistory) == before {
+		t.Error("entering the Jobs tab did not reconcile history")
+	}
+}
+
+// TestManualRefreshDispatchesHistoryOnce asserts the dispatchHistoryIfIdle guard
+// keeps manualRefresh from stacking a second history fetch (it dispatches history
+// directly, then dispatchHeavyVisible must self-skip on the same wave).
+func TestManualRefreshDispatchesHistoryOnce(t *testing.T) {
+	a := newTestApp(t, &store.FakeClient{})
+	a.active = tabJobs
+	before := a.store.Gen(store.SectionHistory)
+
+	a.manualRefresh()
+
+	if got := a.store.Gen(store.SectionHistory) - before; got != 1 {
+		t.Errorf("manualRefresh bumped the history generation %d times; want 1", got)
+	}
+}
+
 // TestTerminalBlurDoesNotFreezeLiveList asserts the live running tier keeps
 // polling regardless of terminal focus: a tea.BlurMsg must not stop the fast-tier
 // squeue dispatch, since focus is not visibility (a visible-but-unfocused pane


### PR DESCRIPTION
Completed jobs sometimes only updated after a manual refresh.

**Root cause (confirmed by a full refresh-path audit).** The job-history base (completed jobs) was on no ticker — `dispatchHistory` ran only at Init, on manual `r`, and on the >8-vanished bulk path. So the only steady-state path to promote a finished job to its terminal state was the single-shot completion overlay: one `scontrol show jobid` lookup when the job leaves `squeue`. The common `squeue`-vs-`scontrol` COMPLETING race (squeue drops the job a moment before scontrol reports it terminal) returns "not found", which was silently dropped with no retry. The job then lingered — relabeled `UNKNOWN` (running at startup) or its row gone (started mid-session) — until `r`.

**Fix.** Reconcile the history base on the slow tier while the Jobs tab is visible (its only consumer), plus immediately on entering the Jobs tab. A missed completion self-heals within one slow cycle instead of needing `r`; the overlay still gives instant updates for the common terminal-at-vanish case; `HistoryStats` reconciles too. `dispatchHistoryIfIdle` self-skips while a history fetch is in flight, so Init/`manualRefresh` never stack a second fetch. History stays unpolled off the Jobs tab (no extra controller load there).

Tests: slow-tick reconciles on the Jobs tab / skips off it; entering Jobs reconciles; manualRefresh dispatches history exactly once; and an end-to-end store test that a stale `UNKNOWN` row heals to `COMPLETED` on the next history refresh.