### PR TITLE
feat(go): modify jobs via scontrol from the job-detail modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ A terminal UI for monitoring Slurm jobs. It auto-refreshes, summarizes jobs, nod
 - Tabs for Jobs, Nodes, Users, Priority, and Logs
 - Cluster-load sidebar: free vs. allocated nodes/CPU/memory/GPU, and the pending queue
 - Quick filtering (`/`), sorting (`o`), and job cancellation (`c`)
+- Job modification from the detail view (`m`): array throttle, partition, time
+  limit, QOS, hold/release, or any raw `scontrol update` field
 - Configurable themes and vim/emacs keybindings
 
 ## Installation

--- a/internal/slurm/client.go
+++ b/internal/slurm/client.go
@@ -364,6 +364,56 @@ func (c *Client) CancelJob(ctx context.Context, jobID string) error {
 	return nil
 }
 
+// safeUpdateKey validates a "scontrol update" field name before it reaches a
+// command.
+var safeUpdateKey = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*$`)
+
+// UpdateJob modifies one field of a job via "scontrol update JobId=<id>
+// Key=Value". The key is validated here; the value is passed through as a single
+// argv element (no shell parsing) and scontrol itself validates it, so a refusal
+// (e.g. a non-admin raising TimeLimit) surfaces via the wrapped stderr.
+func (c *Client) UpdateJob(ctx context.Context, jobID, key, value string) error {
+	jobID = NormalizeArrayJobID(jobID)
+	if err := validateJobID(jobID); err != nil {
+		return err
+	}
+	key = strings.TrimSpace(key)
+	if !safeUpdateKey.MatchString(key) {
+		return fmt.Errorf("invalid scontrol field name: %q", key)
+	}
+	// A JobId field would silently retarget the update to a different job than
+	// the one the caller displays and reports on.
+	if strings.EqualFold(key, "jobid") {
+		return fmt.Errorf("field %q cannot be set via update", key)
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return errors.New("value cannot be empty")
+	}
+	if _, err := c.runner.Run(ctx, "scontrol", "update", "JobId="+jobID, key+"="+value); err != nil {
+		return fmt.Errorf("scontrol update error: %w", err)
+	}
+	return nil
+}
+
+// HoldJob holds (hold=true) or releases (hold=false) a job via "scontrol
+// hold|release". A pending array leader is normalized to its base id, which
+// holds or releases the whole array.
+func (c *Client) HoldJob(ctx context.Context, jobID string, hold bool) error {
+	jobID = NormalizeArrayJobID(jobID)
+	if err := validateJobID(jobID); err != nil {
+		return err
+	}
+	verb := "release"
+	if hold {
+		verb = "hold"
+	}
+	if _, err := c.runner.Run(ctx, "scontrol", verb, jobID); err != nil {
+		return fmt.Errorf("scontrol %s error: %w", verb, err)
+	}
+	return nil
+}
+
 // validateUsername enforces the safe-username pattern, rejecting empty or
 // unsafe-character usernames before they reach a command.
 func validateUsername(username string) error {

--- a/internal/slurm/client_test.go
+++ b/internal/slurm/client_test.go
@@ -298,3 +298,96 @@ func TestClientErrorsPropagate(t *testing.T) {
 		t.Errorf("err = %v, want runner error to propagate", err)
 	}
 }
+
+// TestClientUpdateJob verifies the exact scontrol update command line.
+func TestClientUpdateJob(t *testing.T) {
+	r := &fixtureRunner{outputs: map[string]string{"scontrol": ""}}
+	c := NewClient(r, WithUsername("alice"))
+
+	if err := c.UpdateJob(context.Background(), "12345", "ArrayTaskThrottle", "8"); err != nil {
+		t.Fatal(err)
+	}
+	call := lastCall(r)
+	want := []string{"update", "JobId=12345", "ArrayTaskThrottle=8"}
+	if call.Name != "scontrol" || len(call.Args) != len(want) {
+		t.Fatalf("scontrol update command mismatch: %v %v", call.Name, call.Args)
+	}
+	for i, a := range want {
+		if call.Args[i] != a {
+			t.Errorf("arg[%d] = %q; want %q", i, call.Args[i], a)
+		}
+	}
+}
+
+// TestClientUpdateJobNormalizesArrayLeader verifies a pending array leader id is
+// normalized to its base id before the update.
+func TestClientUpdateJobNormalizesArrayLeader(t *testing.T) {
+	r := &fixtureRunner{outputs: map[string]string{"scontrol": ""}}
+	c := NewClient(r, WithUsername("alice"))
+
+	if err := c.UpdateJob(context.Background(), "12345_[0-99]", "Partition", "p.hpcl91"); err != nil {
+		t.Fatal(err)
+	}
+	if !argsContain(lastCall(r), "JobId=12345") {
+		t.Errorf("array leader not normalized: %v", lastCall(r).Args)
+	}
+}
+
+// TestClientUpdateJobRejectsBadInput verifies no command runs for an invalid
+// key, an empty value, or a bad job id.
+func TestClientUpdateJobRejectsBadInput(t *testing.T) {
+	r := &fixtureRunner{outputs: map[string]string{"scontrol": ""}}
+	c := NewClient(r, WithUsername("alice"))
+
+	cases := []struct{ id, key, value string }{
+		{"12345", "Bad Key", "x"},
+		{"12345", "Key=Injected", "x"},
+		{"12345", "", "x"},
+		{"12345", "Partition", ""},
+		{"bad id", "Partition", "x"},
+		{"12345", "JobId", "99999"},
+		{"12345", "jobid", "99999"},
+	}
+	for _, tc := range cases {
+		if err := c.UpdateJob(context.Background(), tc.id, tc.key, tc.value); err == nil {
+			t.Errorf("UpdateJob(%q, %q, %q): expected error", tc.id, tc.key, tc.value)
+		}
+	}
+	if len(r.calls) != 0 {
+		t.Errorf("scontrol called despite invalid input: %v", r.calls)
+	}
+}
+
+// TestClientHoldJob verifies the hold and release verbs.
+func TestClientHoldJob(t *testing.T) {
+	r := &fixtureRunner{outputs: map[string]string{"scontrol": ""}}
+	c := NewClient(r, WithUsername("alice"))
+
+	if err := c.HoldJob(context.Background(), "12345", true); err != nil {
+		t.Fatal(err)
+	}
+	call := lastCall(r)
+	if call.Name != "scontrol" || call.Args[0] != "hold" || !argsContain(call, "12345") {
+		t.Errorf("hold command mismatch: %v %v", call.Name, call.Args)
+	}
+
+	if err := c.HoldJob(context.Background(), "12345_[0-99]", false); err != nil {
+		t.Fatal(err)
+	}
+	call = lastCall(r)
+	if call.Args[0] != "release" || !argsContain(call, "12345") {
+		t.Errorf("release command mismatch: %v", call.Args)
+	}
+}
+
+// TestClientHoldJobRejectsBadID verifies no command runs for an invalid job id.
+func TestClientHoldJobRejectsBadID(t *testing.T) {
+	r := &fixtureRunner{outputs: map[string]string{}}
+	c := NewClient(r, WithUsername("alice"))
+	if err := c.HoldJob(context.Background(), "bad id", true); err == nil {
+		t.Error("expected validation error")
+	}
+	if len(r.calls) != 0 {
+		t.Errorf("scontrol called despite invalid ID: %v", r.calls)
+	}
+}

--- a/internal/store/client.go
+++ b/internal/store/client.go
@@ -38,6 +38,10 @@ type SlurmClient interface {
 	NodeDetail(ctx context.Context, nodeName string) (slurm.JobDetail, error)
 	// CancelJob cancels a job via scancel.
 	CancelJob(ctx context.Context, jobID string) error
+	// UpdateJob modifies one field of a job via "scontrol update".
+	UpdateJob(ctx context.Context, jobID, key, value string) error
+	// HoldJob holds (hold=true) or releases a job via "scontrol hold|release".
+	HoldJob(ctx context.Context, jobID string, hold bool) error
 	// CompletedJobRecord returns a history record for a just-finished job sourced
 	// from the controller (scontrol), not slurmdbd, so a job that finishes during a
 	// session can be merged into history without a sacct query. found is false when

--- a/internal/store/fake.go
+++ b/internal/store/fake.go
@@ -34,6 +34,8 @@ type FakeClient struct {
 	JobDetailErr       error
 	NodeDetailErr      error
 	CancelJobErr       error
+	UpdateJobErr       error
+	HoldJobErr         error
 	CompletedJobErr    error
 
 	// LastJobDetailID is the job ID passed to the most recent JobDetail call.
@@ -42,6 +44,14 @@ type FakeClient struct {
 	LastNodeDetailName string
 	// LastCancelJobID is the job ID passed to the most recent CancelJob call.
 	LastCancelJobID string
+	// LastUpdateJobID, LastUpdateKey, and LastUpdateValue record the most recent
+	// UpdateJob call.
+	LastUpdateJobID string
+	LastUpdateKey   string
+	LastUpdateValue string
+	// LastHoldJobID and LastHold record the most recent HoldJob call.
+	LastHoldJobID string
+	LastHold      bool
 	// LastCompletedJobID is the job ID passed to the most recent CompletedJobRecord call.
 	LastCompletedJobID string
 	// LastHistoryDays is the day window passed to the most recent JobHistory call.
@@ -101,6 +111,18 @@ func (f *FakeClient) NodeDetail(_ context.Context, nodeName string) (slurm.JobDe
 func (f *FakeClient) CancelJob(_ context.Context, jobID string) error {
 	f.LastCancelJobID = jobID
 	return f.CancelJobErr
+}
+
+// UpdateJob implements SlurmClient.
+func (f *FakeClient) UpdateJob(_ context.Context, jobID, key, value string) error {
+	f.LastUpdateJobID, f.LastUpdateKey, f.LastUpdateValue = jobID, key, value
+	return f.UpdateJobErr
+}
+
+// HoldJob implements SlurmClient.
+func (f *FakeClient) HoldJob(_ context.Context, jobID string, hold bool) error {
+	f.LastHoldJobID, f.LastHold = jobID, hold
+	return f.HoldJobErr
 }
 
 // CompletedJobRecord implements SlurmClient.

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -27,3 +27,7 @@ type (
 	// GPUEntry is a single GPU allocation parsed from a TRES or Gres string.
 	GPUEntry = slurm.GPUEntry
 )
+
+// IsTerminalState reports whether a JobState string denotes a finished job,
+// re-exported for the ui layer (same depguard reasoning as the type aliases).
+func IsTerminalState(state string) bool { return slurm.IsTerminalState(state) }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -558,6 +558,30 @@ func (a App) handleModalMsg(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		a.pushToast("Cancelled job " + msg.JobID)
 		return a, a.manualRefresh(), true // refresh so the job leaves the list
 
+	case modals.OpenModifyMsg:
+		if store.IsTerminalState(msg.Fields["JobState"]) {
+			a.pushToast("Cannot modify " + msg.JobID + ": job is not active (" + msg.Fields["JobState"] + ")")
+			return a, nil, true
+		}
+		return a, a.pushModal(modals.NewJobModify(a.client, a.styles, msg.JobID, msg.Fields)), true
+
+	case modals.ModifyRequestedMsg:
+		if msg.Err != nil {
+			a.pushToast("Modify failed for " + msg.JobID + ": " + msg.Err.Error())
+			return a, nil, true
+		}
+		a.pushToast("Updated job " + msg.JobID + " (" + msg.Desc + ")")
+		a.detailCache.Evict(msg.JobID)
+		cmds := []tea.Cmd{a.manualRefresh()}
+		// The detail modal underneath still shows the pre-modification render;
+		// re-Init it so the evicted cache forces a fresh fetch.
+		if n := len(a.modals); n > 0 {
+			if d, ok := a.modals[n-1].(*modals.JobDetail); ok {
+				cmds = append(cmds, d.Init())
+			}
+		}
+		return a, tea.Batch(cmds...), true
+
 	case modals.LogToastMsg:
 		a.pushToast(msg.Text)
 		return a, nil, true

--- a/internal/ui/modals/job_detail.go
+++ b/internal/ui/modals/job_detail.go
@@ -58,6 +58,9 @@ type JobDetail struct {
 	stdout string
 	stderr string
 	errMsg string
+	// fields is the parsed scontrol detail, kept so "m" can open the modify
+	// modal with current values pre-filled.
+	fields map[string]string
 }
 
 // NewJobDetail builds a job-detail modal for jobID at live state. The cache is
@@ -77,7 +80,7 @@ func NewJobDetail(client store.SlurmClient, cache *JobDetailCache, styles theme.
 		spin:   sp,
 	}
 	d.box.SetTitle("Job Details — " + jobID)
-	d.box.SetFooter("o stdout   e stderr   ↑/↓ scroll   Esc close")
+	d.box.SetFooter("o stdout   e stderr   m modify   ↑/↓ scroll   Esc close")
 	return d
 }
 
@@ -111,6 +114,7 @@ func (d *JobDetail) fetchCmd() tea.Cmd {
 func (d *JobDetail) applyEntry(e cachedDetail) {
 	d.loading = false
 	d.stdout, d.stderr, d.errMsg = e.stdout, e.stderr, e.err
+	d.fields = e.fields
 	if e.err != "" {
 		d.box.SetContent(d.styles.Error.Render("Error: " + e.err))
 		return
@@ -146,6 +150,8 @@ func (d *JobDetail) Update(msg tea.Msg) (Modal, tea.Cmd, bool) {
 			return d, d.openLog(d.stdout, "stdout"), false
 		case "e":
 			return d, d.openLog(d.stderr, "stderr"), false
+		case "m":
+			return d, d.openModify(), false
 		}
 		cmd := d.box.ScrollUpdate(msg)
 		return d, cmd, false
@@ -166,6 +172,7 @@ func (d *JobDetail) applyLoaded(msg jobDetailLoadedMsg) {
 	}
 	content := formatJobDetail(msg.detail, d.styles)
 	d.stdout, d.stderr = stdoutStderrPaths(msg.detail.Fields)
+	d.fields = msg.detail.Fields
 	d.errMsg = ""
 	d.box.SetContent(content)
 	d.box.GotoTop()
@@ -175,7 +182,19 @@ func (d *JobDetail) applyLoaded(msg jobDetailLoadedMsg) {
 		stderr:  d.stderr,
 		source:  msg.detail.Source,
 		state:   d.state,
+		fields:  msg.detail.Fields,
 	})
+}
+
+// openModify emits an OpenModifyMsg carrying the loaded scontrol fields so the
+// root can push the modify modal with current values. Before the detail has
+// loaded (or after a failed fetch) there is nothing to modify, so it is a no-op.
+func (d *JobDetail) openModify() tea.Cmd {
+	if d.fields == nil {
+		return nil
+	}
+	jobID, fields := d.jobID, d.fields
+	return func() tea.Msg { return OpenModifyMsg{JobID: jobID, Fields: fields} }
 }
 
 // openLog emits an OpenLogMsg for path. When the path is empty it emits an
@@ -214,6 +233,7 @@ func (d *JobDetail) ShortHelp() []key.Binding {
 	return []key.Binding{
 		key.NewBinding(key.WithKeys("o"), key.WithHelp("o", "stdout")),
 		key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "stderr")),
+		key.NewBinding(key.WithKeys("m"), key.WithHelp("m", "modify")),
 		key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "close")),
 	}
 }

--- a/internal/ui/modals/job_detail_cache.go
+++ b/internal/ui/modals/job_detail_cache.go
@@ -19,6 +19,9 @@ type cachedDetail struct {
 	// err is a non-empty fetch error message, cached so a failed lookup is not
 	// re-attempted on every open within the same state.
 	err string
+	// fields is the parsed scontrol detail backing the render, kept so the
+	// modify modal can pre-fill current values on a cache hit.
+	fields map[string]string
 }
 
 // JobDetailCache memoizes rendered job details keyed by normalized job id and
@@ -65,6 +68,29 @@ func (c *JobDetailCache) Get(jobID, wantState string) (cachedDetail, bool) {
 // Put stores a rendered detail for jobID at the given live state.
 func (c *JobDetailCache) Put(jobID string, e cachedDetail) {
 	c.entries[normalizeID(jobID)] = e
+}
+
+// Evict removes the cached entries for jobID's whole job family — the exact
+// entry plus the array leader and sibling tasks sharing its base id. The root
+// calls it after a successful modification: the job's state usually does not
+// change, so SyncStates would keep serving the pre-modification render, and an
+// array-scoped update (e.g. ArrayTaskThrottle) targets the leader while the
+// modal was opened for one task.
+func (c *JobDetailCache) Evict(jobID string) {
+	base := baseJobID(normalizeID(jobID))
+	for id := range c.entries {
+		if baseJobID(id) == base {
+			delete(c.entries, id)
+		}
+	}
+}
+
+// baseJobID strips a "_<task>" suffix so array tasks share a family key.
+func baseJobID(jobID string) string {
+	if i := strings.IndexByte(jobID, '_'); i >= 0 {
+		return jobID[:i]
+	}
+	return jobID
 }
 
 // SyncStates evicts cached entries whose live state has changed since they were

--- a/internal/ui/modals/job_detail_cache_test.go
+++ b/internal/ui/modals/job_detail_cache_test.go
@@ -59,3 +59,24 @@ func TestCacheNormalizesArrayTasks(t *testing.T) {
 		t.Error("array-range and base id should share a cache key")
 	}
 }
+
+// TestCacheEvictRemovesJobFamily asserts Evict drops the exact entry plus the
+// array leader and sibling tasks sharing the base id, and nothing else.
+func TestCacheEvictRemovesJobFamily(t *testing.T) {
+	c := NewJobDetailCache()
+	c.Put("12345", cachedDetail{state: "PENDING"})
+	c.Put("12345_3", cachedDetail{state: "RUNNING"})
+	c.Put("12345_7", cachedDetail{state: "RUNNING"})
+	c.Put("99999", cachedDetail{state: "RUNNING"})
+
+	c.Evict("12345_7")
+
+	for _, id := range []string{"12345", "12345_3", "12345_7"} {
+		if _, ok := c.entries[id]; ok {
+			t.Errorf("entry %s survived Evict of a family member", id)
+		}
+	}
+	if _, ok := c.entries["99999"]; !ok {
+		t.Error("unrelated job evicted")
+	}
+}

--- a/internal/ui/modals/job_detail_test.go
+++ b/internal/ui/modals/job_detail_test.go
@@ -164,3 +164,35 @@ func TestJobDetailEscCloses(t *testing.T) {
 		t.Error("esc should close the job-detail modal")
 	}
 }
+
+// TestJobDetailMOpensModify asserts "m" emits an OpenModifyMsg carrying the
+// loaded scontrol fields, and is a no-op before the detail has loaded.
+func TestJobDetailMOpensModify(t *testing.T) {
+	fc := &store.FakeClient{
+		JobDetailData: store.JobDetail{
+			Source: "scontrol",
+			Fields: map[string]string{"JobId": "12345", "JobState": "RUNNING", "Partition": "p.hpcl91"},
+		},
+	}
+	d := NewJobDetail(fc, NewJobDetailCache(), testStyles(), "12345", "RUNNING")
+	d.SetSize(80, 24)
+
+	_, cmd, _ := d.Update(tea.KeyPressMsg{Code: 'm', Text: "m"})
+	if cmd != nil {
+		t.Error("m before the detail loads must be a no-op")
+	}
+
+	fetch := d.Init()
+	d.Update(firstMsg(fetch))
+	_, cmd, done := d.Update(tea.KeyPressMsg{Code: 'm', Text: "m"})
+	if done {
+		t.Error("m must not close the detail modal")
+	}
+	msg, ok := firstMsg(cmd).(OpenModifyMsg)
+	if !ok {
+		t.Fatalf("m produced %T; want OpenModifyMsg", firstMsg(cmd))
+	}
+	if msg.JobID != "12345" || msg.Fields["Partition"] != "p.hpcl91" {
+		t.Errorf("OpenModifyMsg = %+v; want job 12345 with loaded fields", msg)
+	}
+}

--- a/internal/ui/modals/job_modify.go
+++ b/internal/ui/modals/job_modify.go
@@ -1,0 +1,337 @@
+package modals
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/pjhartout/stoei/internal/store"
+	"github.com/pjhartout/stoei/internal/ui/theme"
+)
+
+// OpenModifyMsg asks the root to push the job-modify modal for a job. The
+// job-detail modal emits it when the user presses "m"; the root refuses it for a
+// finished job (toast) and otherwise pushes the modal over the detail.
+type OpenModifyMsg struct {
+	// JobID is the job to modify.
+	JobID string
+	// Fields is the job's parsed scontrol detail, used to pre-fill current values.
+	Fields map[string]string
+}
+
+// ModifyRequestedMsg is emitted after a modification was attempted. The root
+// toasts the outcome and, on success, evicts the detail cache and refreshes.
+type ModifyRequestedMsg struct {
+	// JobID is the job the modification targeted.
+	JobID string
+	// Desc describes the applied change (e.g. "Partition=p.hpcl91" or "hold").
+	Desc string
+	// Err is the scontrol error, or nil on success.
+	Err error
+}
+
+// modifyTimeout bounds the scontrol update/hold/release command.
+const modifyTimeout = 10 * time.Second
+
+// modifyRowKind classifies a row of the modify picker.
+type modifyRowKind int
+
+const (
+	// rowField edits one curated scontrol field via the input step.
+	rowField modifyRowKind = iota
+	// rowHold holds the job immediately (no input step).
+	rowHold
+	// rowRelease releases a held job immediately (no input step).
+	rowRelease
+	// rowRaw is the freeform Key=Value fallback for any other scontrol field.
+	rowRaw
+)
+
+// modifyRow is one selectable entry in the modify picker.
+type modifyRow struct {
+	kind modifyRowKind
+	// key is the scontrol field name (rowField only).
+	key string
+	// value is the field's current value, pre-filled into the input.
+	value string
+	// target overrides the job id the update applies to (the array leader for
+	// ArrayTaskThrottle); empty means the modal's job id.
+	target string
+}
+
+// label returns the row's display name.
+func (r modifyRow) label() string {
+	switch r.kind {
+	case rowHold:
+		return "Hold"
+	case rowRelease:
+		return "Release"
+	case rowRaw:
+		return "Other…"
+	default:
+		return r.key
+	}
+}
+
+// curatedFields are the scontrol update fields offered to every job, in display
+// order. ArrayTaskThrottle is prepended for array jobs only.
+var curatedFields = []string{"Partition", "TimeLimit", "QOS", "Nice", "JobName"}
+
+// jobHeld reports whether the job is held (zero priority or a JobHeld* reason).
+func jobHeld(fields map[string]string) bool {
+	return fields["Priority"] == "0" || strings.Contains(fields["Reason"], "JobHeld")
+}
+
+// modifyRows builds the picker rows for a job from its scontrol fields.
+func modifyRows(fields map[string]string) []modifyRow {
+	var rows []modifyRow
+	if fields["ArrayJobId"] != "" {
+		// Throttle lives on the array leader, so the update targets it, not a task.
+		rows = append(rows, modifyRow{
+			kind:   rowField,
+			key:    "ArrayTaskThrottle",
+			value:  fields["ArrayTaskThrottle"],
+			target: fields["ArrayJobId"],
+		})
+	}
+	for _, k := range curatedFields {
+		rows = append(rows, modifyRow{kind: rowField, key: k, value: fields[k]})
+	}
+	if jobHeld(fields) {
+		rows = append(rows, modifyRow{kind: rowRelease})
+	} else {
+		rows = append(rows, modifyRow{kind: rowHold})
+	}
+	rows = append(rows, modifyRow{kind: rowRaw})
+	return rows
+}
+
+// JobModify is the two-step modify modal opened with "m" from the job detail:
+// pick a field (current values shown), then edit its value in a pre-filled
+// input. Hold/Release rows apply immediately, and the "Other…" row accepts a
+// freeform Key=Value for any scontrol field not in the curated list. The
+// scontrol IO runs in a Cmd off the update loop; scontrol is the validator and
+// its error becomes the outcome toast.
+type JobModify struct {
+	styles theme.Styles
+	client store.SlurmClient
+
+	jobID   string
+	rows    []modifyRow
+	cursor  int
+	editing bool
+	input   textinput.Model
+	errMsg  string
+}
+
+// NewJobModify builds the modify picker for jobID from its scontrol fields.
+func NewJobModify(client store.SlurmClient, styles theme.Styles, jobID string, fields map[string]string) *JobModify {
+	return &JobModify{
+		styles: styles,
+		client: client,
+		jobID:  jobID,
+		rows:   modifyRows(fields),
+		input:  textinput.New(),
+	}
+}
+
+// Init has nothing to start until a field is picked.
+func (m *JobModify) Init() tea.Cmd { return nil }
+
+// Update handles picker navigation, the input step, and applying the change.
+func (m *JobModify) Update(msg tea.Msg) (Modal, tea.Cmd, bool) {
+	km, ok := msg.(tea.KeyPressMsg)
+	if !ok {
+		// Non-key messages (paste, cursor blink) belong to the input while it
+		// is focused; dropping them would swallow pasted text.
+		if m.editing {
+			var cmd tea.Cmd
+			m.input, cmd = m.input.Update(msg)
+			return m, cmd, false
+		}
+		return m, nil, false
+	}
+	if m.editing {
+		return m.updateEditing(km)
+	}
+	switch km.String() {
+	case "esc", "q":
+		return m, nil, true
+	case "up", "k":
+		if m.cursor > 0 {
+			m.cursor--
+		}
+		return m, nil, false
+	case "down", "j":
+		if m.cursor < len(m.rows)-1 {
+			m.cursor++
+		}
+		return m, nil, false
+	case "enter":
+		return m.activate()
+	}
+	return m, nil, false
+}
+
+// activate acts on the selected row: hold/release apply immediately, field and
+// raw rows open the input step.
+func (m *JobModify) activate() (Modal, tea.Cmd, bool) {
+	row := m.rows[m.cursor]
+	switch row.kind {
+	case rowHold:
+		return m, m.applyHold(true), true
+	case rowRelease:
+		return m, m.applyHold(false), true
+	case rowRaw:
+		m.startEditing("", "Key=Value (e.g. Requeue=1)")
+	default:
+		m.startEditing(row.value, "New value for "+row.key)
+	}
+	return m, textinput.Blink, false
+}
+
+// startEditing switches to the input step, pre-filled with value.
+func (m *JobModify) startEditing(value, placeholder string) {
+	m.editing = true
+	m.errMsg = ""
+	m.input.SetValue(value)
+	m.input.CursorEnd()
+	m.input.Placeholder = placeholder
+	m.input.Focus()
+}
+
+// updateEditing handles keys during the input step: esc steps back to the
+// picker, enter applies, anything else edits the input.
+func (m *JobModify) updateEditing(km tea.KeyPressMsg) (Modal, tea.Cmd, bool) {
+	switch km.String() {
+	case "esc":
+		m.editing = false
+		m.input.Blur()
+		return m, nil, false
+	case "enter":
+		return m.submit()
+	}
+	var cmd tea.Cmd
+	m.input, cmd = m.input.Update(km)
+	return m, cmd, false
+}
+
+// submit validates the typed value and issues the update Cmd. An empty or
+// unchanged value steps back to the picker; a raw entry without "=" shows an
+// inline error and stays in the input.
+func (m *JobModify) submit() (Modal, tea.Cmd, bool) {
+	row := m.rows[m.cursor]
+	val := strings.TrimSpace(m.input.Value())
+	if val == "" || (row.kind == rowField && val == row.value) {
+		m.editing = false
+		m.input.Blur()
+		return m, nil, false
+	}
+	key := row.key
+	target := row.target
+	if row.kind == rowRaw {
+		var found bool
+		key, val, found = strings.Cut(val, "=")
+		key, val = strings.TrimSpace(key), strings.TrimSpace(val)
+		if !found || key == "" || val == "" {
+			m.errMsg = "Enter as Key=Value"
+			return m, nil, false
+		}
+	}
+	if target == "" {
+		target = m.jobID
+	}
+	return m, m.applyUpdate(target, key, val), true
+}
+
+// applyUpdate returns a Cmd that runs the scontrol update off the update loop
+// and reports the outcome as a ModifyRequestedMsg.
+func (m *JobModify) applyUpdate(target, key, value string) tea.Cmd {
+	client, jobID := m.client, m.jobID
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), modifyTimeout)
+		defer cancel()
+		err := client.UpdateJob(ctx, target, key, value)
+		return ModifyRequestedMsg{JobID: jobID, Desc: key + "=" + value, Err: err}
+	}
+}
+
+// applyHold returns a Cmd that holds or releases the job off the update loop
+// and reports the outcome as a ModifyRequestedMsg.
+func (m *JobModify) applyHold(hold bool) tea.Cmd {
+	client, jobID := m.client, m.jobID
+	desc := "release"
+	if hold {
+		desc = "hold"
+	}
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), modifyTimeout)
+		defer cancel()
+		err := client.HoldJob(ctx, jobID, hold)
+		return ModifyRequestedMsg{JobID: jobID, Desc: desc, Err: err}
+	}
+}
+
+// View renders the picker list or the input step.
+func (m *JobModify) View() string {
+	title := m.styles.Title.Render("Modify Job — " + m.jobID)
+	var body string
+	if m.editing {
+		row := m.rows[m.cursor]
+		prompt := "New value for " + row.key
+		if row.kind == rowRaw {
+			prompt = "scontrol field as Key=Value"
+		}
+		lines := []string{m.styles.Text.Render(prompt), "", m.styles.Text.Render(m.input.View())}
+		if m.errMsg != "" {
+			lines = append(lines, "", m.styles.Error.Render(m.errMsg))
+		}
+		lines = append(lines, "", m.styles.Subtle.Render("Enter to apply   Esc back"))
+		body = lipgloss.JoinVertical(lipgloss.Left, lines...)
+	} else {
+		lines := make([]string, 0, len(m.rows)+2)
+		for i, row := range m.rows {
+			label := row.label()
+			if row.kind == rowField && row.value != "" {
+				label += "  " + m.styles.Subtle.Render("("+row.value+")")
+			}
+			if i == m.cursor {
+				lines = append(lines, m.styles.Selection.Render("> "+label))
+			} else {
+				lines = append(lines, m.styles.Text.Render("  "+label))
+			}
+		}
+		lines = append(lines, "", m.styles.Subtle.Render("↑/↓ choose   Enter select   Esc close"))
+		body = lipgloss.JoinVertical(lipgloss.Left, lines...)
+	}
+	return m.styles.Modal.Render(lipgloss.JoinVertical(lipgloss.Left, title, "", body))
+}
+
+// SetSize sets the input width.
+func (m *JobModify) SetSize(w, _ int) {
+	mw, _ := modalSize(w, 24)
+	m.input.SetWidth(max(mw-modalChromeWidth, 10))
+}
+
+// SetStyles re-themes the modal.
+func (m *JobModify) SetStyles(styles theme.Styles) { m.styles = styles }
+
+// ShortHelp returns the modify modal's bindings.
+func (m *JobModify) ShortHelp() []key.Binding {
+	return []key.Binding{
+		key.NewBinding(key.WithKeys("up", "down"), key.WithHelp("↑/↓", "choose")),
+		key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
+		key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back/close")),
+	}
+}
+
+// FullHelp returns the expanded bindings.
+func (m *JobModify) FullHelp() [][]key.Binding { return [][]key.Binding{m.ShortHelp()} }
+
+// Compile-time assertion that JobModify satisfies Modal.
+var _ Modal = (*JobModify)(nil)

--- a/internal/ui/modals/job_modify_test.go
+++ b/internal/ui/modals/job_modify_test.go
@@ -1,0 +1,279 @@
+package modals
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/pjhartout/stoei/internal/store"
+)
+
+// runningFields returns a plausible scontrol field map for a running job.
+func runningFields() map[string]string {
+	return map[string]string{
+		"JobId":     "12345",
+		"JobName":   "train",
+		"JobState":  "RUNNING",
+		"Partition": "p.hpcl91",
+		"TimeLimit": "1-00:00:00",
+		"QOS":       "normal",
+		"Nice":      "0",
+		"Priority":  "1000",
+	}
+}
+
+// keyText builds a printable-character key press.
+func keyText(s string) tea.KeyPressMsg {
+	return tea.KeyPressMsg{Code: rune(s[0]), Text: s}
+}
+
+// selectRow moves the cursor to the row with the given label and returns false
+// when no such row exists.
+func selectRow(m *JobModify, label string) bool {
+	for i, r := range m.rows {
+		if r.label() == label {
+			m.cursor = i
+			return true
+		}
+	}
+	return false
+}
+
+// TestModifyRowsCurated asserts the picker offers the curated fields plus Hold
+// and Other, and no throttle row for a non-array job.
+func TestModifyRowsCurated(t *testing.T) {
+	m := NewJobModify(&store.FakeClient{}, testStyles(), "12345", runningFields())
+	var labels []string
+	for _, r := range m.rows {
+		labels = append(labels, r.label())
+	}
+	got := strings.Join(labels, ",")
+	want := "Partition,TimeLimit,QOS,Nice,JobName,Hold,Other…"
+	if got != want {
+		t.Errorf("rows = %s; want %s", got, want)
+	}
+}
+
+// TestModifyRowsArrayAndHeld asserts an array job gets a throttle row targeting
+// the array leader and a held job gets Release instead of Hold.
+func TestModifyRowsArrayAndHeld(t *testing.T) {
+	fields := runningFields()
+	fields["ArrayJobId"] = "12345"
+	fields["ArrayTaskThrottle"] = "4"
+	fields["JobState"] = "PENDING"
+	fields["Priority"] = "0"
+	fields["Reason"] = "JobHeldUser"
+
+	m := NewJobModify(&store.FakeClient{}, testStyles(), "12345_7", fields)
+	if m.rows[0].key != "ArrayTaskThrottle" || m.rows[0].target != "12345" || m.rows[0].value != "4" {
+		t.Errorf("throttle row = %+v; want key ArrayTaskThrottle targeting leader 12345 with value 4", m.rows[0])
+	}
+	if !selectRow(m, "Release") {
+		t.Error("held job should offer Release")
+	}
+	if selectRow(m, "Hold") {
+		t.Error("held job should not offer Hold")
+	}
+}
+
+// TestModifyFieldEditApplies drives picking a field, editing the value, and
+// applying: the FakeClient must receive the update and the modal must close with
+// a ModifyRequestedMsg.
+func TestModifyFieldEditApplies(t *testing.T) {
+	fc := &store.FakeClient{}
+	m := NewJobModify(fc, testStyles(), "12345", runningFields())
+	m.SetSize(80, 24)
+
+	if !selectRow(m, "Partition") {
+		t.Fatal("no Partition row")
+	}
+	m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !m.editing {
+		t.Fatal("Enter on a field row should open the input step")
+	}
+	if m.input.Value() != "p.hpcl91" {
+		t.Errorf("input pre-fill = %q; want current value p.hpcl91", m.input.Value())
+	}
+
+	m.input.SetValue("p.hpcl94g")
+	_, cmd, done := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !done {
+		t.Error("applying should close the modal")
+	}
+	msg, ok := firstMsg(cmd).(ModifyRequestedMsg)
+	if !ok {
+		t.Fatalf("apply produced %T; want ModifyRequestedMsg", firstMsg(cmd))
+	}
+	if msg.JobID != "12345" || msg.Err != nil {
+		t.Errorf("msg = %+v; want JobID 12345 with nil Err", msg)
+	}
+	if fc.LastUpdateJobID != "12345" || fc.LastUpdateKey != "Partition" || fc.LastUpdateValue != "p.hpcl94g" {
+		t.Errorf("UpdateJob called with (%q, %q, %q); want (12345, Partition, p.hpcl94g)",
+			fc.LastUpdateJobID, fc.LastUpdateKey, fc.LastUpdateValue)
+	}
+}
+
+// TestModifyUnchangedValueStepsBack asserts submitting the unchanged value does
+// not issue an update but returns to the picker.
+func TestModifyUnchangedValueStepsBack(t *testing.T) {
+	fc := &store.FakeClient{}
+	m := NewJobModify(fc, testStyles(), "12345", runningFields())
+	selectRow(m, "Partition")
+	m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	_, cmd, done := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter}) // unchanged pre-fill
+	if done || cmd != nil || m.editing {
+		t.Errorf("unchanged submit: done=%v cmd=%v editing=%v; want back to picker with no update", done, cmd != nil, m.editing)
+	}
+	if fc.LastUpdateKey != "" {
+		t.Error("unchanged submit must not call UpdateJob")
+	}
+}
+
+// TestModifyThrottleTargetsArrayLeader asserts the throttle update is issued
+// against the array leader id, not the task id the detail was opened for.
+func TestModifyThrottleTargetsArrayLeader(t *testing.T) {
+	fields := runningFields()
+	fields["ArrayJobId"] = "12345"
+	fields["ArrayTaskThrottle"] = "4"
+	fc := &store.FakeClient{}
+	m := NewJobModify(fc, testStyles(), "12345_7", fields)
+
+	selectRow(m, "ArrayTaskThrottle")
+	m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m.input.SetValue("8")
+	_, cmd, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	firstMsg(cmd)
+	if fc.LastUpdateJobID != "12345" {
+		t.Errorf("throttle update targeted %q; want array leader 12345", fc.LastUpdateJobID)
+	}
+	if fc.LastUpdateKey != "ArrayTaskThrottle" || fc.LastUpdateValue != "8" {
+		t.Errorf("update = %s=%s; want ArrayTaskThrottle=8", fc.LastUpdateKey, fc.LastUpdateValue)
+	}
+}
+
+// TestModifyHoldApplies asserts Enter on the Hold row calls HoldJob(true)
+// without an input step.
+func TestModifyHoldApplies(t *testing.T) {
+	fc := &store.FakeClient{}
+	m := NewJobModify(fc, testStyles(), "12345", runningFields())
+	if !selectRow(m, "Hold") {
+		t.Fatal("no Hold row")
+	}
+	_, cmd, done := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !done {
+		t.Error("hold should close the modal")
+	}
+	msg, ok := firstMsg(cmd).(ModifyRequestedMsg)
+	if !ok || msg.Desc != "hold" {
+		t.Fatalf("hold produced %v; want ModifyRequestedMsg with Desc hold", firstMsg(cmd))
+	}
+	if fc.LastHoldJobID != "12345" || !fc.LastHold {
+		t.Errorf("HoldJob called with (%q, %v); want (12345, true)", fc.LastHoldJobID, fc.LastHold)
+	}
+}
+
+// TestModifyRawParsesKeyValue asserts the freeform row splits Key=Value and
+// rejects input without "=" with an inline error, staying open.
+func TestModifyRawParsesKeyValue(t *testing.T) {
+	fc := &store.FakeClient{}
+	m := NewJobModify(fc, testStyles(), "12345", runningFields())
+	selectRow(m, "Other…")
+	m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	m.input.SetValue("Requeue")
+	_, _, done := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if done || m.errMsg == "" {
+		t.Error("raw input without = should stay open with an inline error")
+	}
+
+	m.input.SetValue("Requeue=1")
+	_, cmd, done := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !done {
+		t.Error("valid raw input should apply and close")
+	}
+	if _, ok := firstMsg(cmd).(ModifyRequestedMsg); !ok {
+		t.Fatalf("raw apply produced %T; want ModifyRequestedMsg", firstMsg(cmd))
+	}
+	if fc.LastUpdateKey != "Requeue" || fc.LastUpdateValue != "1" {
+		t.Errorf("update = %s=%s; want Requeue=1", fc.LastUpdateKey, fc.LastUpdateValue)
+	}
+}
+
+// TestModifyEscBehavior asserts esc steps back from the input to the picker and
+// closes from the picker, and typed keys reach the input (q must type, not quit).
+func TestModifyEscBehavior(t *testing.T) {
+	m := NewJobModify(&store.FakeClient{}, testStyles(), "12345", runningFields())
+	selectRow(m, "JobName")
+	m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	m.Update(keyText("q"))
+	if !m.editing || !strings.Contains(m.input.Value(), "q") {
+		t.Error("typing q in the input step must edit the value, not close")
+	}
+
+	_, _, done := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if done || m.editing {
+		t.Error("esc in the input step should return to the picker, not close")
+	}
+	_, _, done = m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if !done {
+		t.Error("esc in the picker should close the modal")
+	}
+}
+
+// TestModifyErrorPropagates asserts a client error rides back in the msg.
+func TestModifyErrorPropagates(t *testing.T) {
+	fc := &store.FakeClient{UpdateJobErr: errors.New("scontrol update error")}
+	m := NewJobModify(fc, testStyles(), "12345", runningFields())
+	selectRow(m, "QOS")
+	m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m.input.SetValue("high")
+	_, cmd, _ := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	msg := firstMsg(cmd).(ModifyRequestedMsg)
+	if msg.Err == nil {
+		t.Error("client error must propagate in ModifyRequestedMsg.Err")
+	}
+}
+
+// TestModifyReleaseApplies asserts Enter on the Release row of a held job calls
+// HoldJob(id, false), and that a HoldJob error propagates in the msg.
+func TestModifyReleaseApplies(t *testing.T) {
+	fields := runningFields()
+	fields["JobState"] = "PENDING"
+	fields["Priority"] = "0"
+	fields["Reason"] = "JobHeldUser"
+	fc := &store.FakeClient{HoldJobErr: errors.New("scontrol release error")}
+	m := NewJobModify(fc, testStyles(), "12345", fields)
+	if !selectRow(m, "Release") {
+		t.Fatal("no Release row on a held job")
+	}
+	_, cmd, done := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if !done {
+		t.Error("release should close the modal")
+	}
+	msg, ok := firstMsg(cmd).(ModifyRequestedMsg)
+	if !ok || msg.Desc != "release" {
+		t.Fatalf("release produced %v; want ModifyRequestedMsg with Desc release", firstMsg(cmd))
+	}
+	if fc.LastHoldJobID != "12345" || fc.LastHold {
+		t.Errorf("HoldJob called with (%q, %v); want (12345, false)", fc.LastHoldJobID, fc.LastHold)
+	}
+	if msg.Err == nil {
+		t.Error("HoldJob error must propagate in ModifyRequestedMsg.Err")
+	}
+}
+
+// TestModifyPasteReachesInput asserts a bracketed-paste message inserts text
+// into the focused input instead of being dropped.
+func TestModifyPasteReachesInput(t *testing.T) {
+	m := NewJobModify(&store.FakeClient{}, testStyles(), "12345", runningFields())
+	selectRow(m, "QOS")
+	m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m.input.SetValue("")
+	m.Update(tea.PasteMsg{Content: "high"})
+	if m.input.Value() != "high" {
+		t.Errorf("pasted value = %q; want %q", m.input.Value(), "high")
+	}
+}


### PR DESCRIPTION
Adds in-app job modification backed by `scontrol`. Pressing `m` in the job-detail modal opens a two-step modify modal: pick a field (`ArrayTaskThrottle`, `Partition`, `TimeLimit`, `QOS`, `Nice`, `JobName` — current values pre-filled from the cached scontrol detail), apply Hold/Release directly, or enter any other field via a freeform `Key=Value` fallback. `ArrayTaskThrottle` updates correctly target the array leader even when a task's detail is open.

New `slurm.Client.UpdateJob`/`HoldJob` methods shell out to `scontrol update`/`hold`/`release` through the `Runner` seam with validated job IDs and field names; `JobId` is rejected as an updatable field so a raw entry can never silently retarget another job. The `store.SlurmClient` interface and `FakeClient` are extended accordingly. On success the root toasts the change, evicts the job-detail cache for the whole job family (leader plus sibling tasks), re-fetches the open detail, and triggers a fast refresh; failures surface scontrol's stderr in the toast, leaving authorization to slurmctld.